### PR TITLE
Import json in the doc itself instead of setup

### DIFF
--- a/docs/source/tutorials/data_preparation.rst
+++ b/docs/source/tutorials/data_preparation.rst
@@ -214,7 +214,6 @@ to use the |create_dataset| function:
 
 .. testsetup:: create-dataset
 
-  import json
   from pathlib import Path
   config = {"name": "foo", "data": {}}
   Path("source_a.csv").write_text("a,b\n0,0")
@@ -226,6 +225,7 @@ to use the |create_dataset| function:
   
 .. testcode:: create-dataset
 
+  import json
   from movici_simulation_core.preprocessing.dataset_creator import create_dataset
 
   dataset = create_dataset(config)


### PR DESCRIPTION
Describe your changes
--------------------

In the data prepartion tutorial:

https://github.com/nginfra/movici-simulation-core/blob/f2ca8e88bc20933b28f4f1262b8e8e5de6b0c66f/docs/source/tutorials/data_preparation.rst#L215-L235

`json` module is imported in the `testsetup` section, but to be able to properly use the code snippet without changes, it should maybe be imported in `testcode` section.


Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
