### PR TITLE
Fix dataset creator for entities without attributes, support dataset type

### DIFF
--- a/movici_simulation_core/json_schemas/dataset_creator.json
+++ b/movici_simulation_core/json_schemas/dataset_creator.json
@@ -31,6 +31,9 @@
     "display_name": {
       "type": "string"
     },
+    "type": {
+      "type":  "string"
+    },
     "version": {
       "const": 4
     },

--- a/movici_simulation_core/preprocessing/dataset_creator.py
+++ b/movici_simulation_core/preprocessing/dataset_creator.py
@@ -175,6 +175,7 @@ class MetadataSetup(DatasetOperation):
         ("general", _missing),
         ("name", _missing),
         ("display_name", _missing),
+        ("type", _missing),
         ("version", 4),
     )
 
@@ -213,16 +214,20 @@ class SpecialValueCollection(DatasetOperation):
                 return {key: config["special"]}
             return {}
         else:
-            return functools.reduce(
-                lambda prev, curr: {**prev, **curr},
-                (
-                    self.extract_special_values(
-                        conf, key=f"{key}.{new_key}" if key else new_key, level=level + 1
-                    )
-                    for new_key, conf in config.items()
-                    if not new_key.startswith("__")
-                ),
-            )
+            try:
+                return functools.reduce(
+                    lambda prev, curr: {**prev, **curr},
+                    (
+                        self.extract_special_values(
+                            conf, key=f"{key}.{new_key}" if key else new_key, level=level + 1
+                        )
+                        for new_key, conf in config.items()
+                        if not new_key.startswith("__")
+                    ),
+                )
+            except TypeError:
+                # no attributes found (emtpy iterable)
+                return {}
 
 
 def load_csv(obj: str):

--- a/tests/preprocessing/test_dataset_creator.py
+++ b/tests/preprocessing/test_dataset_creator.py
@@ -803,6 +803,17 @@ class TestSpecialValueCollection:
             "expected": {},
         },
         {
+            "name": "No additional attributes",
+            "config": {
+                "data": {
+                    "some_entities": {
+                        "__meta__": {"source": "foo"},
+                    }
+                }
+            },
+            "expected": {},
+        },
+        {
             "name": "Can collect special values",
             "config": {
                 "data": {
@@ -1286,6 +1297,7 @@ def test_create_dataset(create_geojson):
         "__sources__": {"my_source": str(geojson)},
         "name": "test_dataset",
         "display_name": "Test Dataset",
+        "type": "some_type",
         "data": {
             "test_entities": {
                 "__meta__": {"source": "my_source", "geometry": "points"},
@@ -1307,6 +1319,7 @@ def test_create_dataset(create_geojson):
     assert result == {
         "name": "test_dataset",
         "display_name": "Test Dataset",
+        "type": "some_type",
         "version": 4,
         "epsg_code": 28992,
         "bounding_box": [exp_x1, exp_y1, exp_x2, exp_y2],


### PR DESCRIPTION
Describe your changes
--------------------
* Fixes #10 
* Additionally this PR adds support for the dataset type field

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
