### PR TITLE
Fix enum conversion bug where True was written instead of integer

### DIFF
--- a/.bumpversion.app
+++ b/.bumpversion.app
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.7.0
+current_version = 2.7.1
 allow_dirty = True
 
 [bumpversion:file:VERSION]

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 # Do not update directly, use `make bump-version` instead or see `README.md` for further instructions
-2.7.0
+2.7.1

--- a/movici_simulation_core/__init__.py
+++ b/movici_simulation_core/__init__.py
@@ -83,4 +83,4 @@ __all__ = [
     "UpdateDataClient",
 ]
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"

--- a/movici_simulation_core/preprocessing/dataset_creator.py
+++ b/movici_simulation_core/preprocessing/dataset_creator.py
@@ -414,7 +414,7 @@ class EnumInfo:
         self.items: t.Dict[str, int] = {val: idx for idx, val in enumerate(enum_values)}
 
     def ensure(self, text: str) -> int:
-        if pos := self.get_pos(text) is not None:
+        if (pos := self.get_pos(text)) is not None:
             return pos
         return self.add(text)
 

--- a/tests/preprocessing/test_dataset_creator.py
+++ b/tests/preprocessing/test_dataset_creator.py
@@ -603,7 +603,8 @@ class TestEnumConversion:
         return {
             "enumerable": [
                 Point(0, 0, attributes={"attr": "bar"}),
-                Point(1, 1, attributes={"attr": "baz"}),
+                Point(1, 1, attributes={"attr": "bar"}),
+                Point(2, 2, attributes={"attr": "baz"}),
             ],
         }
 
@@ -702,7 +703,7 @@ class TestEnumConversion:
     )
     def test_converts_string_into_enum_values(self, config, sources, dataset):
         result = EnumConversion(config)(dataset, sources=sources)
-        assert result["data"]["foo_entities"]["attr"] == [0, 1]
+        assert result["data"]["foo_entities"]["attr"] == [0, 0, 1]
 
     @pytest.mark.parametrize(
         "config, sources_dict",


### PR DESCRIPTION
Describe your changes
--------------------
Due to missing parentheses, only the first occurence of an enum string would be converted to integer in dataset creators. All others would be substituted by `True`

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
