### PR TITLE
Work around PROJ binary compatibility 

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -44,10 +44,6 @@ jobs:
         with:
           os: ${{ matrix.os }}
 
-      - name: Install Fiona
-        if: startsWith(matrix.os, 'windows')
-        run: pip install fiona==1.9a2
-
       - name: Install dependencies
         run: |
           pip install -e .[models,dev]

--- a/movici_simulation_core/ae_wrapper/__init__.py
+++ b/movici_simulation_core/ae_wrapper/__init__.py
@@ -1,6 +1,6 @@
 # Fiona is shipped with its own version of PROJ. Aequilibrae also uses PROJ through spatialite.
 # We need to be sure to use Fiona's version, otherwise Fiona crashes upon import. So if we at some
-# point want to use Fiona (eg throught DatasetCreator), we need to import Fiona here to be sure
+# point want to use Fiona (eg through DatasetCreator), we need to import Fiona here to be sure
 # that its version is used. See also https://github.com/Toblerity/Fiona/issues/1161
 
 import fiona  # noqa

--- a/movici_simulation_core/ae_wrapper/__init__.py
+++ b/movici_simulation_core/ae_wrapper/__init__.py
@@ -1,3 +1,10 @@
+# Fiona is shipped with its own version of PROJ. Aequilibrae also uses PROJ through spatialite.
+# We need to be sure to use Fiona's version, otherwise Fiona crashes upon import. So if we at some
+# point want to use Fiona (eg throught DatasetCreator), we need to import Fiona here to be sure
+# that its version is used. See also https://github.com/Toblerity/Fiona/issues/1161
+
+import fiona  # noqa
+
 from .collections import AssignmentResultCollection, GraphPath, LinkCollection, NodeCollection
 from .id_generator import IdGenerator
 from .point_generator import PointGenerator

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ orjson>=3
 pyzmq
 msgpack
 click
-geopandas<0.11; sys_platform == "linux"
 geopandas
 jsonschema
 pyproj

--- a/tests/simulation/test_simulation.py
+++ b/tests/simulation/test_simulation.py
@@ -229,18 +229,18 @@ class TestModelRunner:
         assert stream_run.call_count == 1
 
     def test_entry_point_handles_exception(self, runner, stream_run):
-        stream_run.side_effect = ValueError
+        stream_run.side_effect = ValueError("An expected error")
         runner.entry_point()
         error_resp = runner._get_orchestrator_socket().send.call_args[0][0]
         assert isinstance(error_resp, ErrorMessage)
 
     def test_shuts_down_model_on_exception(self, runner, stream_run):
-        stream_run.side_effect = ValueError
+        stream_run.side_effect = ValueError("An expected error")
         runner.entry_point()
         assert DummyModel.shutdown.call_count == 1
 
     def test_entry_point_exits_on_exception(self, runner, stream_run, sys_exit):
-        stream_run.side_effect = ValueError
+        stream_run.side_effect = ValueError("An expected error")
         runner.entry_point()
         assert sys_exit.call_args == call(1)
 


### PR DESCRIPTION
Both Fiona and Spatialite use PROJ. We need to be sure to use fiona's version or run into binary incompatibilities. See also https://github.com/Toblerity/Fiona/issues/1161. This allows us to use a later geopandas version (that used to cause the test suite to crash)

Also, some cleanup

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
