### PR TITLE
Use attribute instead of mode for evacuation point resolution model

### DIFF
--- a/.bumpversion.app
+++ b/.bumpversion.app
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.10.0
+current_version = 2.10.1
 allow_dirty = True
 
 [bumpversion:file:VERSION]

--- a/VERSION
+++ b/VERSION
@@ -1,2 +1,2 @@
 # Do not update directly, use `make bump-version` instead or see `README.md` for further instructions
-2.10.0
+2.10.1

--- a/movici_simulation_core/__init__.py
+++ b/movici_simulation_core/__init__.py
@@ -83,4 +83,4 @@ __all__ = [
     "UpdateDataClient",
 ]
 
-__version__ = "2.10.0"
+__version__ = "2.10.1"

--- a/movici_simulation_core/json_schemas/models/evacuation_point_resolution.json
+++ b/movici_simulation_core/json_schemas/models/evacuation_point_resolution.json
@@ -11,19 +11,31 @@
       "movici.type": "dataset"
     },
     "evacuation_points": {
-      "type": "string",
-      "movici.type": "entityGroup"
+      "$ref": "#/$defs/evacuationLabelDef"
     },
     "road_segments": {
-      "type": "string",
-      "movici.type": "entityGroup"
-    },
-    "mode": {
-      "type": "string",
-      "enum": [ "id", "label" ]
+      "$ref": "#/$defs/evacuationLabelDef"
     }
-
   },
-  "additionalProperties": false
-
+  "additionalProperties": false,
+  "$defs": {
+    "attributeDef": {
+      "type": "string",
+      "movici.type": "attribute"
+    },
+    "evacuationLabelDef": {
+      "type": "object",
+      "required": [ "entity_group", "attribute" ],
+      "properties": {
+        "entity_group": {
+          "type": "string",
+          "movici.type": "entityGroup"
+        },
+        "attribute": {
+          "type": "string",
+          "movici.type": "attribute"
+        }
+      }
+    }
+  }
 }

--- a/movici_simulation_core/models/evacuation_point_resolution/evacuation_point_resolution_model.py
+++ b/movici_simulation_core/models/evacuation_point_resolution/evacuation_point_resolution_model.py
@@ -8,34 +8,30 @@ from movici_simulation_core import (
     INIT,
     PUB,
     SUB,
+    AttributeSchema,
     AttributeSpec,
     DataType,
     TrackedModel,
     TrackedState,
     field,
 )
-from movici_simulation_core.attributes import Label
 from movici_simulation_core.core.arrays import TrackedCSRArray
-from movici_simulation_core.core.attribute import OPT
 from movici_simulation_core.core.entity_group import EntityGroup
-from movici_simulation_core.exceptions import NotReady
 from movici_simulation_core.json_schemas import SCHEMA_PATH
 from movici_simulation_core.validate import ensure_schema, validate_and_process
 
 Evacuation_RoadIds = AttributeSpec("evacuation.road_ids", DataType(int, csr=True))
 Evacuation_LastId = AttributeSpec("evacuation.last_id", int)
-
+Evacuation_EvacuationPointId = AttributeSpec("evacuation.evacuation_point_id", int)
 MODEL_CONFIG_SCHEMA_PATH = SCHEMA_PATH / "models/evacuation_point_resolution.json"
 
 
 class EvacuationPoints(EntityGroup):
     road_ids = field(Evacuation_RoadIds, flags=INIT)
-    label = field(Label, flags=OPT)
 
 
 class RoadSegments(EntityGroup):
     last_id = field(Evacuation_LastId, flags=SUB)
-    label = field(Label, flags=PUB)
 
 
 class EvacuatonPointResolution(TrackedModel, name="evacuation_point_resolution"):
@@ -46,33 +42,60 @@ class EvacuatonPointResolution(TrackedModel, name="evacuation_point_resolution")
     def __init__(self, model_config: dict):
         validate_and_process(model_config, schema=ensure_schema(MODEL_CONFIG_SCHEMA_PATH))
 
-        model_config.setdefault("evacuation_points", "evacuation_point_entities")
-        model_config.setdefault("road_segments", "road_segment_entities")
-        model_config.setdefault("mode", "id")
+        model_config.setdefault(
+            "evacuation_points", {"entity_group": "evacuation_point_entities", "attribute": "id"}
+        )
+        model_config.setdefault(
+            "road_segments",
+            {
+                "entity_group": "road_segment_entities",
+                "attribute": Evacuation_EvacuationPointId.name,
+            },
+        )
         super().__init__(model_config)
 
-    def setup(self, state: TrackedState, **_):
+    def setup(self, state: TrackedState, schema: AttributeSchema, **_):
         dataset = self.config["dataset"]
-        points_name = self.config["evacuation_points"]
-        roads_name = self.config["road_segments"]
-        self.evac_points = state.register_entity_group(dataset, EvacuationPoints(points_name))
-        self.roads = state.register_entity_group(dataset, RoadSegments(roads_name))
+        points = self.config["evacuation_points"]
+        roads = self.config["road_segments"]
+
+        self.evac_points = self._register_entity_group(
+            state, schema, dataset, EvacuationPoints, config=points, flag=INIT
+        )
+
+        self.roads = self._register_entity_group(
+            state, schema, dataset, RoadSegments, config=roads, flag=PUB
+        )
+
+    @staticmethod
+    def _register_entity_group(
+        state: TrackedState,
+        schema: AttributeSchema,
+        dataset: str,
+        entity_cls: t.Type[EntityGroup],
+        config: dict,
+        flag: int,
+    ):
+        entity_group = state.register_entity_group(dataset, entity_cls(config["entity_group"]))
+        if (attr := config["attribute"]) != "id":
+            spec = schema.get_spec(attr, default_data_type=DataType(int))
+            entity_group.register_attribute(spec, flags=flag)
+        return entity_group
 
     def initialize(self, **_):
-        if self.config["mode"] == "label":
-            if not self.evac_points.label.is_initialized():
-                raise NotReady()
-            labels = self.evac_points.label.array
+        if (attr := self.config["evacuation_points"]["attribute"]) != "id":
+            labels = self.evac_points.get_attribute(attr).array
         else:
-            labels = np.arange(len(self.evac_points))
+            labels = self.evac_points.index.ids
         self.create_label_mapping(self.evac_points.road_ids.csr, labels)
 
     def update(self, **_):
         changed_indices = np.flatnonzero(self.roads.last_id.changed)
         if len(changed_indices) == 0:
             changed_indices = np.arange(len(self.roads))
+        target = self.roads.get_attribute(self.config["road_segments"]["attribute"])
         for idx in changed_indices:
-            self.roads.label[idx] = self.label_mapping[self.roads.last_id[idx]]
+            target[idx] = self.label_mapping[self.roads.last_id[idx]]
 
     def create_label_mapping(
         self, road_ids: TrackedCSRArray, labels: np.ndarray
@@ -85,4 +108,4 @@ class EvacuatonPointResolution(TrackedModel, name="evacuation_point_resolution")
 
     @classmethod
     def get_schema_attributes(cls):
-        return [Evacuation_LastId, Evacuation_RoadIds]
+        return [Evacuation_LastId, Evacuation_RoadIds, Evacuation_EvacuationPointId]


### PR DESCRIPTION
Evacuation point resolution model configures with attribute instead of mode

Describe your changes
--------------------


Copyright license
-----------------

Please tick the following box:
 - [ ] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to 
 re-/sublicense my contribution
