### PR TITLE
Add INPSource DataSource for EPANET INP files

### DIFF
--- a/docs/source/tutorials/data_preparation.rst
+++ b/docs/source/tutorials/data_preparation.rst
@@ -640,6 +640,88 @@ Below is given an example of a dataset creator config snippet
   }
 
 
+.. _dataset-creator-recipes-read-inp:
+
+Read an EPANET INP file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+EPANET INP files are supported via ``WNTR``. An ``inp`` source is a multi-entity source
+that exposes the six WNTR collections as separate sub-sources, each selected from the
+parent source using dot notation ``"<source_name>.<entity_type>"``:
+
+* Node types: ``junctions``, ``tanks``, ``reservoirs``
+* Link types: ``pipes``, ``pumps``, ``valves``
+
+Properties available on each sub-source match the attributes of the corresponding WNTR
+object (e.g. ``elevation``, ``diameter``, ``start_node_name``, ``base_head``). The
+synthetic ``name`` property yields the WNTR element name and is useful as a ``reference``
+attribute and as an ``id_link`` key for resolving link-to-node topology.
+
+Caveats:
+
+* The CRS can not be converted for ``inp`` data sources. The CRS must be specified to be
+  the same CRS as the coordinates stored in the INP file.
+* Link sub-sources (``pipes``, ``pumps``, ``valves``) produce line geometries from the
+  coordinates of their start and end nodes. They do not contribute a bounding box.
+* WNTR converts INP values to SI units on read according to the file's flow-units header
+  (e.g. in ``LPS``, pipe diameters expressed in millimeters become meters). Map properties
+  from the WNTR representation, not the raw INP values.
+
+Below is an example of a dataset creator config snippet. A single ``inp`` source is
+declared once, and each entity group references the appropriate sub-source through dot
+notation:
+
+.. code-block::
+
+  {
+    "__meta__": {
+      "crs": "EPSG:28992"
+    },
+    "__sources__": {
+      "network": {
+        "source_type": "inp",
+        "path": "/path/to/network.inp"
+      }
+    },
+    "data": {
+      "water_junction_entities": {
+        "__meta__": {"source": "network.junctions", "geometry": "points"},
+        "reference": {"property": "name"},
+        "water.elevation": {"property": "elevation"}
+      },
+      "water_reservoir_entities": {
+        "__meta__": {"source": "network.reservoirs", "geometry": "points"},
+        "reference": {"property": "name"}
+      },
+      "water_tank_entities": {
+        "__meta__": {"source": "network.tanks", "geometry": "points"},
+        "reference": {"property": "name"}
+      },
+      "water_pipe_entities": {
+        "__meta__": {"source": "network.pipes", "geometry": "lines"},
+        "reference": {"property": "name"},
+        "water.diameter": {"property": "diameter"},
+        "topology.from_node_id": {
+          "property": "start_node_name",
+          "id_link": [
+            {"entity_group": "water_junction_entities", "property": "name"},
+            {"entity_group": "water_reservoir_entities", "property": "name"},
+            {"entity_group": "water_tank_entities", "property": "name"}
+          ]
+        },
+        "topology.to_node_id": {
+          "property": "end_node_name",
+          "id_link": [
+            {"entity_group": "water_junction_entities", "property": "name"},
+            {"entity_group": "water_reservoir_entities", "property": "name"},
+            {"entity_group": "water_tank_entities", "property": "name"}
+          ]
+        }
+      }
+    }
+  }
+
+
 .. _tutorial-dataset-creator-config-schema:
 
 Dataset Creator Config Schema Reference
@@ -695,12 +777,14 @@ DatasetCreatorSource
 | ``type``: ``object``
 
 ``properties``:
-  | ``source_type``: One of ``file``, ``netcdf``. Use ``netcdf`` for NetCDF-files, ``file`` for any
-    other supported geospatial data file
+  | ``source_type``: One of ``file``, ``netcdf``, ``inp``. Use ``netcdf`` for NetCDF-files,
+    ``inp`` for EPANET INP files (read via ``WNTR``), ``file`` for any other supported geospatial
+    data file
   | ``path``: ``string`` location on disk to a source file
 
-Source files are read using ``geopandas`` which uses  ``Fiona`` under the hood and may be any file
-that ``Fiona`` supports as geospatial data, such as ``geojson`` or ``shapefile``
+Source files of ``source_type`` ``file`` are read using ``geopandas`` which uses ``Fiona`` under
+the hood and may be any file that ``Fiona`` supports as geospatial data, such as ``geojson`` or
+``shapefile``
 
 
 .. _DatasetCreatorGeneralSection:

--- a/docs/source/tutorials/data_preparation.rst
+++ b/docs/source/tutorials/data_preparation.rst
@@ -645,7 +645,7 @@ Below is given an example of a dataset creator config snippet
 Read an EPANET INP file
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-EPANET INP files are supported via ``WNTR``. An ``inp`` source is a multi-entity source
+EPANET INP files are supported via ``WNTR``. An ``epanet`` source is a multi-entity source
 that exposes the six WNTR collections as separate sub-sources, each selected from the
 parent source using dot notation ``"<source_name>.<entity_type>"``:
 
@@ -659,7 +659,7 @@ attribute and as an ``id_link`` key for resolving link-to-node topology.
 
 Caveats:
 
-* The CRS can not be converted for ``inp`` data sources. The CRS must be specified to be
+* The CRS can not be converted for ``epanet`` data sources. The CRS must be specified to be
   the same CRS as the coordinates stored in the INP file.
 * Link sub-sources (``pipes``, ``pumps``, ``valves``) produce line geometries from the
   coordinates of their start and end nodes. They do not contribute a bounding box.
@@ -667,7 +667,7 @@ Caveats:
   (e.g. in ``LPS``, pipe diameters expressed in millimeters become meters). Map properties
   from the WNTR representation, not the raw INP values.
 
-Below is an example of a dataset creator config snippet. A single ``inp`` source is
+Below is an example of a dataset creator config snippet. A single ``epanet`` source is
 declared once, and each entity group references the appropriate sub-source through dot
 notation:
 
@@ -679,7 +679,7 @@ notation:
     },
     "__sources__": {
       "network": {
-        "source_type": "inp",
+        "source_type": "epanet",
         "path": "/path/to/network.inp"
       }
     },

--- a/packages/drinking-water/pyproject.toml
+++ b/packages/drinking-water/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
 drinking_water = "movici_drinking_water_model.model:Model"
 drinking_water_attributes = "movici_drinking_water_model.attributes:DrinkingWaterNetworkAttributes"
 
+[project.entry-points."movici.dataset_creator.source"]
+epanet = "movici_drinking_water_model.epanet_source:EPANETSource"
+
 [tool.hatch.version]
 source = "uv-dynamic-versioning"
 

--- a/packages/drinking-water/src/movici_drinking_water_model/epanet_source.py
+++ b/packages/drinking-water/src/movici_drinking_water_model/epanet_source.py
@@ -1,0 +1,169 @@
+"""EPANET INP file DataSource for the dataset creator, backed by WNTR."""
+
+from __future__ import annotations
+
+import typing as t
+from pathlib import Path
+
+import numpy as np
+import wntr
+
+from movici_simulation_core.attributes import (
+    Geometry_Linestring2d,
+    Geometry_X,
+    Geometry_Y,
+)
+from movici_simulation_core.preprocessing import DataSource, MultiEntitySource
+from movici_simulation_core.preprocessing.data_sources import GeometryType
+
+
+class _EPANETEntitySource(DataSource):
+    """DataSource for a single entity type from an EPANET INP file."""
+
+    NODE_TYPES = frozenset({"junctions", "tanks", "reservoirs"})
+    LINK_TYPES = frozenset({"pipes", "pumps", "valves"})
+
+    def __init__(
+        self,
+        get_model: t.Callable[[], "wntr.network.WaterNetworkModel"],
+        entity_type: str,
+    ) -> None:
+        self._get_model = get_model
+        self.entity_type = entity_type
+        self._items: t.Optional[t.List[t.Tuple[str, t.Any]]] = None
+
+    def _get_items(self) -> t.List[t.Tuple[str, t.Any]]:
+        if self._items is None:
+            wn = self._get_model()
+            self._items = list(getattr(wn, self.entity_type)())
+        return self._items
+
+    def get_attribute(self, name: str):
+        items = self._get_items()
+        result: list = []
+        for _name, obj in items:
+            if name == "name":
+                result.append(_name)
+            else:
+                result.append(getattr(obj, name, None))
+        return result
+
+    def get_geometry(self, geometry_type: GeometryType):
+        if self.entity_type in self.NODE_TYPES:
+            if geometry_type != "points":
+                raise ValueError(
+                    f"Node entity '{self.entity_type}' only supports 'points' geometry, "
+                    f"got '{geometry_type}'"
+                )
+            xs, ys = [], []
+            for _, node in self._get_items():
+                if node.coordinates is None:
+                    raise ValueError(f"Node '{_}' has no coordinates")
+                xs.append(node.coordinates[0])
+                ys.append(node.coordinates[1])
+            return {Geometry_X.name: xs, Geometry_Y.name: ys}
+        if self.entity_type in self.LINK_TYPES:
+            if geometry_type != "lines":
+                raise ValueError(
+                    f"Link entity '{self.entity_type}' only supports 'lines' geometry, "
+                    f"got '{geometry_type}'"
+                )
+            wn = self._get_model()
+            lines = []
+            for _name, link in self._get_items():
+                start = wn.get_node(link.start_node_name).coordinates
+                end = wn.get_node(link.end_node_name).coordinates
+                if start is None or end is None:
+                    raise ValueError(f"Link '{_name}' has an endpoint without coordinates")
+                lines.append([[start[0], start[1]], [end[0], end[1]]])
+            return {Geometry_Linestring2d.name: lines}
+        raise ValueError(f"No geometry available for entity type '{self.entity_type}'")
+
+    def get_bounding_box(self):
+        if self.entity_type not in self.NODE_TYPES:
+            return None
+        coords = [n.coordinates for _, n in self._get_items() if n.coordinates is not None]
+        if not coords:
+            return None
+        xs, ys = zip(*coords)
+        return (min(xs), min(ys), max(xs), max(ys))
+
+    def __len__(self):
+        return len(self._get_items())
+
+
+class EPANETSource(MultiEntitySource):
+    r"""Multi-entity source for reading EPANET INP files via WNTR.
+
+    Registered as the ``"epanet"`` source type for the dataset creator. Contains
+    entity types: ``junctions``, ``tanks``, ``reservoirs``, ``pipes``, ``pumps``,
+    ``valves``. Use bracket notation to access individual entity types as
+    ``DataSource``\s::
+
+        source = EPANETSource("network.inp")
+        junctions = source["junctions"]
+        len(junctions)
+        junctions.get_attribute("elevation")
+
+    Multiple ``EPANETSource`` instances sharing the same file path reuse a
+    cached WNTR model. The cache is keyed by resolved absolute path and is
+    never invalidated — edits to the file within one process are not picked up.
+
+    :param file: Path to the INP file
+    """
+
+    _model_cache: t.ClassVar[t.Dict[str, "wntr.network.WaterNetworkModel"]] = {}
+
+    ENTITY_TYPES = frozenset({"junctions", "tanks", "reservoirs", "pipes", "pumps", "valves"})
+
+    def __init__(self, file: t.Union[Path, str]) -> None:
+        self.file = Path(file)
+        self._entity_sources: t.Dict[str, _EPANETEntitySource] = {}
+
+    @classmethod
+    def from_source_info(cls, source_info):
+        """Create from a source info dictionary.
+
+        If ``entity_type`` is present in the source info, returns a single-entity
+        ``DataSource`` for that type; otherwise returns the full multi-entity
+        source.
+        """
+        source = cls(file=source_info["path"])
+        if "entity_type" in source_info:
+            return source[source_info["entity_type"]]
+        return source
+
+    def _get_model(self) -> "wntr.network.WaterNetworkModel":
+        key = str(self.file.resolve())
+        if key not in self._model_cache:
+            self._model_cache[key] = wntr.network.WaterNetworkModel(str(self.file))
+        return self._model_cache[key]
+
+    def keys(self) -> t.Iterable[str]:
+        return iter(sorted(self.ENTITY_TYPES))
+
+    def __getitem__(self, entity_type: str) -> _EPANETEntitySource:
+        if entity_type not in self.ENTITY_TYPES:
+            raise KeyError(
+                f"Unknown entity type '{entity_type}', must be one of {sorted(self.ENTITY_TYPES)}"
+            )
+        if entity_type not in self._entity_sources:
+            self._entity_sources[entity_type] = _EPANETEntitySource(self._get_model, entity_type)
+        return self._entity_sources[entity_type]
+
+    def __contains__(self, entity_type) -> bool:
+        return entity_type in self.ENTITY_TYPES
+
+    def get_bounding_box(self):
+        bboxes = [
+            bbox for et in self.ENTITY_TYPES if (bbox := self[et].get_bounding_box()) is not None
+        ]
+        if not bboxes:
+            return None
+        bboxes_arr = np.stack(bboxes)
+        return (
+            float(bboxes_arr[:, 0].min()),
+            float(bboxes_arr[:, 1].min()),
+            float(bboxes_arr[:, 2].max()),
+            float(bboxes_arr[:, 3].max()),
+        )

--- a/packages/drinking-water/src/movici_drinking_water_model/epanet_source.py
+++ b/packages/drinking-water/src/movici_drinking_water_model/epanet_source.py
@@ -13,7 +13,7 @@ from movici_simulation_core.attributes import (
     Geometry_X,
     Geometry_Y,
 )
-from movici_simulation_core.preprocessing import DataSource, MultiEntitySource
+from movici_simulation_core.preprocessing import DataSource, MultipleEntityTypeSource
 from movici_simulation_core.preprocessing.data_sources import GeometryType
 
 
@@ -25,23 +25,19 @@ class _EPANETEntitySource(DataSource):
 
     def __init__(
         self,
-        get_model: t.Callable[[], "wntr.network.WaterNetworkModel"],
+        model: "wntr.network.WaterNetworkModel",
         entity_type: str,
     ) -> None:
-        self._get_model = get_model
+        self.model = model
         self.entity_type = entity_type
-        self._items: t.Optional[t.List[t.Tuple[str, t.Any]]] = None
 
-    def _get_items(self) -> t.List[t.Tuple[str, t.Any]]:
-        if self._items is None:
-            wn = self._get_model()
-            self._items = list(getattr(wn, self.entity_type)())
-        return self._items
+    @property
+    def _features(self) -> t.Iterator[t.Tuple[str, t.Any]]:
+        return getattr(self.model, self.entity_type)()
 
     def get_attribute(self, name: str):
-        items = self._get_items()
         result: list = []
-        for _name, obj in items:
+        for _name, obj in self._features:
             if name == "name":
                 result.append(_name)
             else:
@@ -56,9 +52,9 @@ class _EPANETEntitySource(DataSource):
                     f"got '{geometry_type}'"
                 )
             xs, ys = [], []
-            for _, node in self._get_items():
+            for _name, node in self._features:
                 if node.coordinates is None:
-                    raise ValueError(f"Node '{_}' has no coordinates")
+                    raise ValueError(f"Node '{_name}' has no coordinates")
                 xs.append(node.coordinates[0])
                 ys.append(node.coordinates[1])
             return {Geometry_X.name: xs, Geometry_Y.name: ys}
@@ -68,11 +64,10 @@ class _EPANETEntitySource(DataSource):
                     f"Link entity '{self.entity_type}' only supports 'lines' geometry, "
                     f"got '{geometry_type}'"
                 )
-            wn = self._get_model()
             lines = []
-            for _name, link in self._get_items():
-                start = wn.get_node(link.start_node_name).coordinates
-                end = wn.get_node(link.end_node_name).coordinates
+            for _name, link in self._features:
+                start = self.model.get_node(link.start_node_name).coordinates
+                end = self.model.get_node(link.end_node_name).coordinates
                 if start is None or end is None:
                     raise ValueError(f"Link '{_name}' has an endpoint without coordinates")
                 lines.append([[start[0], start[1]], [end[0], end[1]]])
@@ -82,17 +77,17 @@ class _EPANETEntitySource(DataSource):
     def get_bounding_box(self):
         if self.entity_type not in self.NODE_TYPES:
             return None
-        coords = [n.coordinates for _, n in self._get_items() if n.coordinates is not None]
+        coords = [n.coordinates for _, n in self._features if n.coordinates is not None]
         if not coords:
             return None
         xs, ys = zip(*coords)
         return (min(xs), min(ys), max(xs), max(ys))
 
     def __len__(self):
-        return len(self._get_items())
+        return sum(1 for _ in self._features)
 
 
-class EPANETSource(MultiEntitySource):
+class EPANETSource(MultipleEntityTypeSource):
     r"""Multi-entity source for reading EPANET INP files via WNTR.
 
     Registered as the ``"epanet"`` source type for the dataset creator. Contains
@@ -105,19 +100,17 @@ class EPANETSource(MultiEntitySource):
         len(junctions)
         junctions.get_attribute("elevation")
 
-    Multiple ``EPANETSource`` instances sharing the same file path reuse a
-    cached WNTR model. The cache is keyed by resolved absolute path and is
-    never invalidated — edits to the file within one process are not picked up.
+    The WNTR model is loaded lazily on first entity-type access and shared across
+    sub-sources of the same ``EPANETSource`` instance.
 
     :param file: Path to the INP file
     """
-
-    _model_cache: t.ClassVar[t.Dict[str, "wntr.network.WaterNetworkModel"]] = {}
 
     ENTITY_TYPES = frozenset({"junctions", "tanks", "reservoirs", "pipes", "pumps", "valves"})
 
     def __init__(self, file: t.Union[Path, str]) -> None:
         self.file = Path(file)
+        self.model: t.Optional["wntr.network.WaterNetworkModel"] = None
         self._entity_sources: t.Dict[str, _EPANETEntitySource] = {}
 
     @classmethod
@@ -133,12 +126,6 @@ class EPANETSource(MultiEntitySource):
             return source[source_info["entity_type"]]
         return source
 
-    def _get_model(self) -> "wntr.network.WaterNetworkModel":
-        key = str(self.file.resolve())
-        if key not in self._model_cache:
-            self._model_cache[key] = wntr.network.WaterNetworkModel(str(self.file))
-        return self._model_cache[key]
-
     def keys(self) -> t.Iterable[str]:
         return iter(sorted(self.ENTITY_TYPES))
 
@@ -147,8 +134,10 @@ class EPANETSource(MultiEntitySource):
             raise KeyError(
                 f"Unknown entity type '{entity_type}', must be one of {sorted(self.ENTITY_TYPES)}"
             )
+        if self.model is None:
+            self.model = wntr.network.WaterNetworkModel(str(self.file))
         if entity_type not in self._entity_sources:
-            self._entity_sources[entity_type] = _EPANETEntitySource(self._get_model, entity_type)
+            self._entity_sources[entity_type] = _EPANETEntitySource(self.model, entity_type)
         return self._entity_sources[entity_type]
 
     def __contains__(self, entity_type) -> bool:

--- a/packages/drinking-water/tests/test_epanet_source.py
+++ b/packages/drinking-water/tests/test_epanet_source.py
@@ -1,0 +1,335 @@
+"""Tests for EPANETSource MultiEntitySource."""
+
+import textwrap
+
+import pytest
+
+from movici_drinking_water_model.epanet_source import EPANETSource
+from movici_simulation_core.preprocessing import MultiEntitySource
+from movici_simulation_core.preprocessing.dataset_creator import (
+    AttributeDataLoading,
+    DatasetCreator,
+    IDGeneration,
+    IDLinking,
+    SourcesSetup,
+)
+
+MINIMAL_INP = textwrap.dedent("""\
+    [TITLE]
+    Test Network
+
+    [JUNCTIONS]
+    ;ID  Elev  Demand  Pattern
+     J1  100   10
+     J2  90    20
+
+    [RESERVOIRS]
+    ;ID  Head  Pattern
+     R1  200
+
+    [TANKS]
+    ;ID  Elevation  InitLevel  MinLevel  MaxLevel  Diameter  MinVol  VolCurve  Overflow
+     T1  150        10         0         20        50        0
+
+    [PIPES]
+    ;ID  Node1  Node2  Length  Diameter  Roughness  MinorLoss  Status
+     P1  J1     J2     1000    300       100        0          Open
+     P2  R1     J1     500     400       100        0          Open
+
+    [PUMPS]
+    ;ID  Node1  Node2  Parameters
+     PU1 T1     J2     POWER 50
+
+    [VALVES]
+    ;ID  Node1  Node2  Diameter  Type  Setting  MinorLoss
+
+    [OPTIONS]
+    Units  LPS
+    Headloss  H-W
+
+    [COORDINATES]
+    ;Node  X-Coord  Y-Coord
+     J1    10.0     20.0
+     J2    30.0     20.0
+     R1    0.0      20.0
+     T1    20.0     40.0
+
+    [END]
+""")
+
+
+@pytest.fixture
+def inp_file(tmp_path):
+    path = tmp_path / "test_network.inp"
+    path.write_text(MINIMAL_INP)
+    yield path
+    EPANETSource._model_cache.clear()
+
+
+class TestEPANETSource:
+    def test_is_multi_entity_source(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert isinstance(source, MultiEntitySource)
+
+    def test_has_all_entity_types(self, inp_file):
+        source = EPANETSource(inp_file)
+        expected = {"junctions", "tanks", "reservoirs", "pipes", "pumps", "valves"}
+        assert set(source.keys()) == expected
+
+    def test_contains_valid_entity_type(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert "junctions" in source
+        assert "bogus" not in source
+
+    def test_invalid_entity_type_raises_key_error(self, inp_file):
+        source = EPANETSource(inp_file)
+        with pytest.raises(KeyError, match="Unknown entity type"):
+            source["bogus"]
+
+    def test_junction_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["junctions"]) == 2
+
+    def test_tank_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["tanks"]) == 1
+
+    def test_reservoir_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["reservoirs"]) == 1
+
+    def test_pipe_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["pipes"]) == 2
+
+    def test_pump_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["pumps"]) == 1
+
+    def test_valve_count(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert len(source["valves"]) == 0
+
+    def test_junction_names(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        assert source.get_attribute("name") == ["J1", "J2"]
+
+    def test_junction_elevation(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        # LPS units: elevation in meters, WNTR keeps as-is
+        assert source.get_attribute("elevation") == [100.0, 90.0]
+
+    def test_junction_base_demand(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        demands = source.get_attribute("base_demand")
+        # LPS units: WNTR converts LPS -> m3/s (/1000)
+        assert demands == pytest.approx([0.01, 0.02], rel=1e-6)
+
+    def test_tank_attributes(self, inp_file):
+        source = EPANETSource(inp_file)["tanks"]
+        assert source.get_attribute("name") == ["T1"]
+        assert source.get_attribute("elevation") == [150.0]
+        assert source.get_attribute("init_level") == [10.0]
+        assert source.get_attribute("min_level") == [0.0]
+        assert source.get_attribute("max_level") == [20.0]
+
+    def test_reservoir_head(self, inp_file):
+        source = EPANETSource(inp_file)["reservoirs"]
+        assert source.get_attribute("name") == ["R1"]
+        assert source.get_attribute("base_head") == [200.0]
+
+    def test_pipe_topology(self, inp_file):
+        source = EPANETSource(inp_file)["pipes"]
+        assert source.get_attribute("start_node_name") == ["J1", "R1"]
+        assert source.get_attribute("end_node_name") == ["J2", "J1"]
+
+    def test_pipe_attributes(self, inp_file):
+        source = EPANETSource(inp_file)["pipes"]
+        assert source.get_attribute("length") == [1000.0, 500.0]
+        # LPS units: diameter in mm, WNTR converts to meters (/1000)
+        assert source.get_attribute("diameter") == pytest.approx([0.3, 0.4], rel=1e-6)
+        assert source.get_attribute("roughness") == [100.0, 100.0]
+
+    def test_pump_topology(self, inp_file):
+        source = EPANETSource(inp_file)["pumps"]
+        assert source.get_attribute("start_node_name") == ["T1"]
+        assert source.get_attribute("end_node_name") == ["J2"]
+
+    def test_node_geometry_points(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        geom = source.get_geometry("points")
+        assert "geometry.x" in geom
+        assert "geometry.y" in geom
+        assert geom["geometry.x"] == [10.0, 30.0]
+        assert geom["geometry.y"] == [20.0, 20.0]
+
+    def test_link_geometry_lines(self, inp_file):
+        source = EPANETSource(inp_file)["pipes"]
+        geom = source.get_geometry("lines")
+        assert "geometry.linestring_2d" in geom
+        lines = geom["geometry.linestring_2d"]
+        assert len(lines) == 2
+        # P1: J1(10,20) -> J2(30,20)
+        assert lines[0] == [[10.0, 20.0], [30.0, 20.0]]
+        # P2: R1(0,20) -> J1(10,20)
+        assert lines[1] == [[0.0, 20.0], [10.0, 20.0]]
+
+    def test_node_geometry_wrong_type_raises(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        with pytest.raises(ValueError, match="only supports 'points'"):
+            source.get_geometry("lines")
+
+    def test_link_geometry_wrong_type_raises(self, inp_file):
+        source = EPANETSource(inp_file)["pipes"]
+        with pytest.raises(ValueError, match="only supports 'lines'"):
+            source.get_geometry("points")
+
+    def test_node_bounding_box(self, inp_file):
+        source = EPANETSource(inp_file)["junctions"]
+        bbox = source.get_bounding_box()
+        assert bbox == (10.0, 20.0, 30.0, 20.0)
+
+    def test_link_bounding_box_is_none(self, inp_file):
+        source = EPANETSource(inp_file)["pipes"]
+        assert source.get_bounding_box() is None
+
+    def test_combined_bounding_box(self, inp_file):
+        source = EPANETSource(inp_file)
+        bbox = source.get_bounding_box()
+        # All nodes: J1(10,20), J2(30,20), R1(0,20), T1(20,40)
+        assert bbox == (0.0, 20.0, 30.0, 40.0)
+
+    def test_from_source_info_with_entity_type(self, inp_file):
+        """from_source_info with entity_type returns a DataSource."""
+        source = EPANETSource.from_source_info(
+            {
+                "source_type": "epanet",
+                "path": str(inp_file),
+                "entity_type": "junctions",
+            }
+        )
+        assert not isinstance(source, MultiEntitySource)
+        assert len(source) == 2
+
+    def test_from_source_info_without_entity_type(self, inp_file):
+        """from_source_info without entity_type returns a MultiEntitySource."""
+        source = EPANETSource.from_source_info(
+            {
+                "source_type": "epanet",
+                "path": str(inp_file),
+            }
+        )
+        assert isinstance(source, MultiEntitySource)
+        assert len(source["junctions"]) == 2
+
+    def test_model_caching(self, inp_file):
+        source = EPANETSource(inp_file)
+        # Access two entity types, model should be loaded once
+        len(source["junctions"])
+        len(source["pipes"])
+        assert source["junctions"]._get_model() is source["pipes"]._get_model()
+
+    def test_model_caching_across_instances(self, inp_file):
+        s1 = EPANETSource(inp_file)
+        s2 = EPANETSource(inp_file)
+        len(s1["junctions"])
+        len(s2["pipes"])
+        assert s1._get_model() is s2._get_model()
+
+    def test_entity_source_is_cached(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert source["junctions"] is source["junctions"]
+
+
+class TestEPANETSourceWithDatasetCreator:
+    """Tests using the multi-entity source with dot notation."""
+
+    @pytest.fixture
+    def config(self, inp_file):
+        path = str(inp_file)
+        return {
+            "name": "test_water",
+            "__sources__": {
+                "network": {
+                    "source_type": "epanet",
+                    "path": path,
+                },
+            },
+            "data": {
+                "water_junction_entities": {
+                    "__meta__": {"source": "network.junctions", "geometry": "points"},
+                    "reference": {"property": "name"},
+                    "water.elevation": {"property": "elevation"},
+                },
+                "water_reservoir_entities": {
+                    "__meta__": {"source": "network.reservoirs", "geometry": "points"},
+                    "reference": {"property": "name"},
+                },
+                "water_tank_entities": {
+                    "__meta__": {"source": "network.tanks", "geometry": "points"},
+                    "reference": {"property": "name"},
+                },
+                "water_pipe_entities": {
+                    "__meta__": {"source": "network.pipes", "geometry": "lines"},
+                    "reference": {"property": "name"},
+                    "water.diameter": {"property": "diameter"},
+                    "topology.from_node_id": {
+                        "property": "start_node_name",
+                        "id_link": [
+                            {"entity_group": "water_junction_entities", "property": "name"},
+                            {"entity_group": "water_reservoir_entities", "property": "name"},
+                            {"entity_group": "water_tank_entities", "property": "name"},
+                        ],
+                    },
+                    "topology.to_node_id": {
+                        "property": "end_node_name",
+                        "id_link": [
+                            {"entity_group": "water_junction_entities", "property": "name"},
+                            {"entity_group": "water_reservoir_entities", "property": "name"},
+                            {"entity_group": "water_tank_entities", "property": "name"},
+                        ],
+                    },
+                },
+            },
+        }
+
+    def test_creates_dataset_with_entities(self, config):
+        dataset = DatasetCreator(
+            [SourcesSetup, AttributeDataLoading, IDGeneration],
+            validate_config=False,
+        ).create(config)
+
+        junctions = dataset["data"]["water_junction_entities"]
+        assert len(junctions["id"]) == 2
+        assert junctions["reference"] == ["J1", "J2"]
+        assert junctions["water.elevation"] == pytest.approx([100.0, 90.0])
+
+        pipes = dataset["data"]["water_pipe_entities"]
+        assert len(pipes["id"]) == 2
+        assert pipes["reference"] == ["P1", "P2"]
+        assert pipes["water.diameter"] == pytest.approx([0.3, 0.4], rel=1e-6)
+
+    def test_id_linking_resolves_topology(self, config):
+        dataset = DatasetCreator(
+            [SourcesSetup, AttributeDataLoading, IDGeneration, IDLinking],
+            validate_config=False,
+        ).create(config)
+
+        pipes = dataset["data"]["water_pipe_entities"]
+
+        name_to_id = {}
+        for eg_name in (
+            "water_junction_entities",
+            "water_reservoir_entities",
+            "water_tank_entities",
+        ):
+            eg = dataset["data"][eg_name]
+            for name, eid in zip(eg["reference"], eg["id"]):
+                name_to_id[name] = eid
+
+        # P1: J1 -> J2
+        assert pipes["topology.from_node_id"][0] == name_to_id["J1"]
+        assert pipes["topology.to_node_id"][0] == name_to_id["J2"]
+        # P2: R1 -> J1
+        assert pipes["topology.from_node_id"][1] == name_to_id["R1"]
+        assert pipes["topology.to_node_id"][1] == name_to_id["J1"]

--- a/packages/drinking-water/tests/test_epanet_source.py
+++ b/packages/drinking-water/tests/test_epanet_source.py
@@ -1,11 +1,11 @@
-"""Tests for EPANETSource MultiEntitySource."""
+"""Tests for EPANETSource MultipleEntityTypeSource."""
 
 import textwrap
 
 import pytest
 
 from movici_drinking_water_model.epanet_source import EPANETSource
-from movici_simulation_core.preprocessing import MultiEntitySource
+from movici_simulation_core.preprocessing import MultipleEntityTypeSource
 from movici_simulation_core.preprocessing.dataset_creator import (
     AttributeDataLoading,
     DatasetCreator,
@@ -62,14 +62,13 @@ MINIMAL_INP = textwrap.dedent("""\
 def inp_file(tmp_path):
     path = tmp_path / "test_network.inp"
     path.write_text(MINIMAL_INP)
-    yield path
-    EPANETSource._model_cache.clear()
+    return path
 
 
 class TestEPANETSource:
     def test_is_multi_entity_source(self, inp_file):
         source = EPANETSource(inp_file)
-        assert isinstance(source, MultiEntitySource)
+        assert isinstance(source, MultipleEntityTypeSource)
 
     def test_has_all_entity_types(self, inp_file):
         source = EPANETSource(inp_file)
@@ -208,33 +207,29 @@ class TestEPANETSource:
                 "entity_type": "junctions",
             }
         )
-        assert not isinstance(source, MultiEntitySource)
+        assert not isinstance(source, MultipleEntityTypeSource)
         assert len(source) == 2
 
     def test_from_source_info_without_entity_type(self, inp_file):
-        """from_source_info without entity_type returns a MultiEntitySource."""
+        """from_source_info without entity_type returns a MultipleEntityTypeSource."""
         source = EPANETSource.from_source_info(
             {
                 "source_type": "epanet",
                 "path": str(inp_file),
             }
         )
-        assert isinstance(source, MultiEntitySource)
+        assert isinstance(source, MultipleEntityTypeSource)
         assert len(source["junctions"]) == 2
 
-    def test_model_caching(self, inp_file):
+    def test_model_shared_across_entity_types(self, inp_file):
         source = EPANETSource(inp_file)
-        # Access two entity types, model should be loaded once
-        len(source["junctions"])
-        len(source["pipes"])
-        assert source["junctions"]._get_model() is source["pipes"]._get_model()
+        assert source["junctions"].model is source["pipes"].model
 
-    def test_model_caching_across_instances(self, inp_file):
-        s1 = EPANETSource(inp_file)
-        s2 = EPANETSource(inp_file)
-        len(s1["junctions"])
-        len(s2["pipes"])
-        assert s1._get_model() is s2._get_model()
+    def test_model_loaded_lazily(self, inp_file):
+        source = EPANETSource(inp_file)
+        assert source.model is None
+        source["junctions"]
+        assert source.model is not None
 
     def test_entity_source_is_cached(self, inp_file):
         source = EPANETSource(inp_file)

--- a/packages/simulation-core/src/movici_simulation_core/json_schemas/dataset_creator.json
+++ b/packages/simulation-core/src/movici_simulation_core/json_schemas/dataset_creator.json
@@ -61,11 +61,7 @@
             ],
             "properties": {
               "source_type": {
-                "type": "string",
-                "enum": [
-                  "file",
-                  "netcdf"
-                ]
+                "type": "string"
               },
               "path": {
                 "type": "string"

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/__init__.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/__init__.py
@@ -1,7 +1,7 @@
 from .data_sources import (
     DataSource,
     GeopandasSource,
-    MultiEntitySource,
+    MultipleEntityTypeSource,
     NetCDFGridSource,
     NumpyDataSource,
     PandasDataSource,
@@ -19,7 +19,7 @@ __all__ = [
     "DatasetCreator",
     "DataSource",
     "GeopandasSource",
-    "MultiEntitySource",
+    "MultipleEntityTypeSource",
     "NetCDFGridSource",
     "NumpyDataSource",
     "PandasDataSource",

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/__init__.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/__init__.py
@@ -1,9 +1,11 @@
 from .data_sources import (
     DataSource,
     GeopandasSource,
+    MultiEntitySource,
     NetCDFGridSource,
     NumpyDataSource,
     PandasDataSource,
+    resolve_source,
 )
 from .dataset_creator import (
     DatasetCreator,
@@ -17,12 +19,14 @@ __all__ = [
     "DatasetCreator",
     "DataSource",
     "GeopandasSource",
+    "MultiEntitySource",
     "NetCDFGridSource",
     "NumpyDataSource",
     "PandasDataSource",
     "create_dataset",
     "get_dataset_creator_schema",
     "register_source_type",
+    "resolve_source",
     "InterpolatingTapefile",
     "TimeDependentAttribute",
 ]

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
@@ -77,7 +77,7 @@ def resolve_source(name: str, sources: "SourcesDict") -> "DataSource":
             raise ValueError(f"Source '{source_name}' not available") from None
         if not isinstance(source, MultipleEntityTypeSource):
             raise TypeError(
-                f"Source '{source_name}' is not a multi-entity source, "
+                f"Source '{source_name}' is not a MultipleEntityTypeSource, "
                 f"cannot select entity type '{entity_type}'"
             )
         try:

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
@@ -24,6 +24,84 @@ from movici_simulation_core.attributes import (
 GeometryType = t.Literal["points", "lines", "polygons", "cells"]
 
 
+class MultiEntitySource:
+    r"""Base class for data sources that provide multiple entity types from a single file or
+    connection, such as a network file that contains both node and link collections.
+
+    Use bracket notation to access individual entity types as ``DataSource``\s::
+
+        source = MySource("network.file")
+        nodes = source["nodes"]  # returns a DataSource
+
+    In dataset creator configs, use dot notation to reference entity types::
+
+        {"source": "network.nodes"}
+    """
+
+    def keys(self) -> t.Iterable[str]:
+        """Return the available entity type names."""
+        raise NotImplementedError
+
+    def __getitem__(self, entity_type: str) -> "DataSource":
+        """Return a ``DataSource`` for the given entity type."""
+        raise NotImplementedError
+
+    def __contains__(self, entity_type: str) -> bool:
+        """Check whether an entity type is available."""
+        raise NotImplementedError
+
+    def to_crs(self, crs: t.Union[str, int, "CRS"]) -> None:
+        """Convert all sub-sources to the target CRS."""
+        return None
+
+    def get_bounding_box(self) -> t.Optional[t.Tuple[float, float, float, float]]:
+        """Return the combined bounding box across all entity types, or ``None``."""
+        return None
+
+
+def resolve_source(name: str, sources: "SourcesDict") -> "DataSource":
+    """Resolve a source reference to a ``DataSource``.
+
+    Supports dot notation for multi-entity sources: ``"source_name.entity_type"``.
+
+    :param name: Source reference, optionally with dot notation
+    :param sources: The sources dictionary
+    :raises ValueError: If the source or entity type is not found
+    :raises TypeError: If a bare name references a ``MultiEntitySource``
+    """
+    if "." in name:
+        source_name, entity_type = name.split(".", 1)
+        try:
+            source = sources[source_name]
+        except KeyError:
+            raise ValueError(f"Source '{source_name}' not available") from None
+        if not isinstance(source, MultiEntitySource):
+            raise TypeError(
+                f"Source '{source_name}' is not a multi-entity source, "
+                f"cannot select entity type '{entity_type}'"
+            )
+        try:
+            return source[entity_type]
+        except KeyError:
+            raise ValueError(
+                f"Entity type '{entity_type}' not found in source '{source_name}'"
+            ) from None
+
+    try:
+        source = sources[name]
+    except KeyError:
+        raise ValueError(f"Source '{name}' not available") from None
+
+    if isinstance(source, MultiEntitySource):
+        available = ", ".join(sorted(source.keys()))
+        raise TypeError(
+            f"Source '{name}' is a multi-entity source; "
+            f"use '{name}.<entity_type>' to select an entity type "
+            f"(available: {available})"
+        )
+    return source
+
+
 class DataSource:
     r"""Base class for creating custom ``DataSource``\s. Subclasses must implement
     ``get_attribute`` and ``__len``. In case the ``DataSource`` handles geospatial data, subclasses
@@ -297,4 +375,4 @@ class NetCDFGridSource(DataSource):
         return np.array(unique_coords, dtype=float), np.array(cells, dtype=np.int32)
 
 
-SourcesDict = t.MutableMapping[str, DataSource]
+SourcesDict = t.MutableMapping[str, t.Union[DataSource, MultiEntitySource]]

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/data_sources.py
@@ -24,7 +24,7 @@ from movici_simulation_core.attributes import (
 GeometryType = t.Literal["points", "lines", "polygons", "cells"]
 
 
-class MultiEntitySource:
+class MultipleEntityTypeSource:
     r"""Base class for data sources that provide multiple entity types from a single file or
     connection, such as a network file that contains both node and link collections.
 
@@ -67,7 +67,7 @@ def resolve_source(name: str, sources: "SourcesDict") -> "DataSource":
     :param name: Source reference, optionally with dot notation
     :param sources: The sources dictionary
     :raises ValueError: If the source or entity type is not found
-    :raises TypeError: If a bare name references a ``MultiEntitySource``
+    :raises TypeError: If a bare name references a ``MultipleEntityTypeSource``
     """
     if "." in name:
         source_name, entity_type = name.split(".", 1)
@@ -75,7 +75,7 @@ def resolve_source(name: str, sources: "SourcesDict") -> "DataSource":
             source = sources[source_name]
         except KeyError:
             raise ValueError(f"Source '{source_name}' not available") from None
-        if not isinstance(source, MultiEntitySource):
+        if not isinstance(source, MultipleEntityTypeSource):
             raise TypeError(
                 f"Source '{source_name}' is not a multi-entity source, "
                 f"cannot select entity type '{entity_type}'"
@@ -92,7 +92,7 @@ def resolve_source(name: str, sources: "SourcesDict") -> "DataSource":
     except KeyError:
         raise ValueError(f"Source '{name}' not available") from None
 
-    if isinstance(source, MultiEntitySource):
+    if isinstance(source, MultipleEntityTypeSource):
         available = ", ".join(sorted(source.keys()))
         raise TypeError(
             f"Source '{name}' is a multi-entity source; "
@@ -375,4 +375,4 @@ class NetCDFGridSource(DataSource):
         return np.array(unique_coords, dtype=float), np.array(cells, dtype=np.int32)
 
 
-SourcesDict = t.MutableMapping[str, t.Union[DataSource, MultiEntitySource]]
+SourcesDict = t.MutableMapping[str, t.Union[DataSource, MultipleEntityTypeSource]]

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/dataset_creator.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/dataset_creator.py
@@ -18,7 +18,7 @@ from movici_simulation_core.json_schemas import PATH
 from .data_sources import (
     DataSource,
     GeometryType,
-    MultiEntitySource,
+    MultipleEntityTypeSource,
     SourcesDict,
     resolve_source,
 )
@@ -131,11 +131,13 @@ class SourcesSetup(DatasetOperation):
     :meth:`register`.
     """
 
-    _source_types: t.ClassVar[t.Dict[str, t.Type[t.Union[DataSource, MultiEntitySource]]]] = {}
+    _source_types: t.ClassVar[
+        t.Dict[str, t.Type[t.Union[DataSource, MultipleEntityTypeSource]]]
+    ] = {}
 
     @classmethod
     def register(
-        cls, name: str, source_cls: t.Type[t.Union[DataSource, MultiEntitySource]]
+        cls, name: str, source_cls: t.Type[t.Union[DataSource, MultipleEntityTypeSource]]
     ) -> None:
         """Register a ``DataSource`` class under ``name``.
 
@@ -167,7 +169,9 @@ class SourcesSetup(DatasetOperation):
         return cls.from_source_info(source_info)
 
     @classmethod
-    def _resolve_source_type(cls, name: str) -> t.Type[t.Union[DataSource, MultiEntitySource]]:
+    def _resolve_source_type(
+        cls, name: str
+    ) -> t.Type[t.Union[DataSource, MultipleEntityTypeSource]]:
         if name in cls._source_types:
             return cls._source_types[name]
         try:
@@ -186,7 +190,9 @@ class SourcesSetup(DatasetOperation):
         return path
 
 
-def register_source_type(name: str, cls: t.Type[t.Union[DataSource, MultiEntitySource]]) -> None:
+def register_source_type(
+    name: str, cls: t.Type[t.Union[DataSource, MultipleEntityTypeSource]]
+) -> None:
     """Register a ``DataSource`` class under ``name`` with :class:`SourcesSetup`.
 
     Convenience module-level shim that delegates to :meth:`SourcesSetup.register`.

--- a/packages/simulation-core/src/movici_simulation_core/preprocessing/dataset_creator.py
+++ b/packages/simulation-core/src/movici_simulation_core/preprocessing/dataset_creator.py
@@ -15,7 +15,13 @@ from jsonschema.validators import validator_for
 from movici_simulation_core.attributes import Grid_GridPoints
 from movici_simulation_core.json_schemas import PATH
 
-from .data_sources import DataSource, GeometryType, SourcesDict
+from .data_sources import (
+    DataSource,
+    GeometryType,
+    MultiEntitySource,
+    SourcesDict,
+    resolve_source,
+)
 
 SOURCE_TYPE_ENTRY_POINT_GROUP = "movici.dataset_creator.source"
 
@@ -125,10 +131,12 @@ class SourcesSetup(DatasetOperation):
     :meth:`register`.
     """
 
-    _source_types: t.ClassVar[t.Dict[str, t.Type[DataSource]]] = {}
+    _source_types: t.ClassVar[t.Dict[str, t.Type[t.Union[DataSource, MultiEntitySource]]]] = {}
 
     @classmethod
-    def register(cls, name: str, source_cls: t.Type[DataSource]) -> None:
+    def register(
+        cls, name: str, source_cls: t.Type[t.Union[DataSource, MultiEntitySource]]
+    ) -> None:
         """Register a ``DataSource`` class under ``name``.
 
         The class must expose a ``from_source_info(source_info)`` classmethod. Source types
@@ -159,7 +167,7 @@ class SourcesSetup(DatasetOperation):
         return cls.from_source_info(source_info)
 
     @classmethod
-    def _resolve_source_type(cls, name: str) -> t.Type[DataSource]:
+    def _resolve_source_type(cls, name: str) -> t.Type[t.Union[DataSource, MultiEntitySource]]:
         if name in cls._source_types:
             return cls._source_types[name]
         try:
@@ -178,7 +186,7 @@ class SourcesSetup(DatasetOperation):
         return path
 
 
-def register_source_type(name: str, cls: t.Type[DataSource]) -> None:
+def register_source_type(name: str, cls: t.Type[t.Union[DataSource, MultiEntitySource]]) -> None:
     """Register a ``DataSource`` class under ``name`` with :class:`SourcesSetup`.
 
     Convenience module-level shim that delegates to :meth:`SourcesSetup.register`.
@@ -373,10 +381,7 @@ class AttributeDataLoading(DatasetOperation):
         return [pipe(loaders, attr) for attr in source.get_attribute(attr_config["property"])]
 
     def get_source(self, source_name):
-        try:
-            return self.sources[source_name]
-        except KeyError:
-            raise ValueError(f"Source '{source_name}' not available") from None
+        return resolve_source(source_name, self.sources)
 
     def get_loaders(self, attr_config):
         def skip_none(loader):
@@ -498,7 +503,7 @@ class BoundingBoxCalculation(DatasetOperation):
         active_sources_keys = {
             eg["__meta__"].get("source") for eg in self.config["data"].values()
         } - {None}
-        return (sources[key] for key in active_sources_keys)
+        return (resolve_source(key, sources) for key in active_sources_keys)
 
 
 class IDGeneration(DatasetOperation):
@@ -519,11 +524,9 @@ class IDGeneration(DatasetOperation):
             entity_data["id"] = [next(ctr) for _ in range(size)]
         return dataset
 
-    def get_entity_count_from_meta(
-        self, entity_meta: dict, sources: t.MutableMapping[str, t.Sized]
-    ) -> int:
-        if source := entity_meta.get("source"):
-            return len(sources[source])
+    def get_entity_count_from_meta(self, entity_meta: dict, sources: SourcesDict) -> int:
+        if source_ref := entity_meta.get("source"):
+            return len(resolve_source(source_ref, sources))
         if count := entity_meta.get("count"):
             return count
         return 0
@@ -622,10 +625,10 @@ class IDLinking(DatasetOperation):
         except KeyError:
             raise ValueError(f"Target entity group '{entity_type}' not defined") from None
 
-        try:
-            source = sources[target_entity_group["__meta__"]["source"]]
-        except KeyError:
-            raise ValueError(f"Source not defined for '{entity_type}'") from None
+        source_ref = target_entity_group["__meta__"].get("source")
+        if source_ref is None:
+            raise ValueError(f"Source not defined for '{entity_type}'")
+        source = resolve_source(source_ref, sources)
 
         try:
             ids = dataset["data"][entity_type]["id"]

--- a/packages/simulation-core/tests/preprocessing/test_dataset_creator.py
+++ b/packages/simulation-core/tests/preprocessing/test_dataset_creator.py
@@ -1442,15 +1442,6 @@ class TestSchemaValidation:
                 },
             },
             {**min_required, "extra": "key"},
-            {
-                **min_required,
-                "__sources__": {
-                    "foo": {
-                        "source_type": "invalid",  # invalid source type
-                        "path": "/some/other/path",
-                    },
-                },
-            },
             {"__meta__": {"crs": 12.3}, **min_required},
             {"general": {"enum": ["invalid"]}, **min_required},
             {"general": {"special": ["invalid"]}, **min_required},

--- a/packages/simulation-core/tests/preprocessing/test_resolve_source.py
+++ b/packages/simulation-core/tests/preprocessing/test_resolve_source.py
@@ -1,0 +1,74 @@
+"""Tests for resolve_source and MultiEntitySource."""
+
+import pytest
+
+from movici_simulation_core.preprocessing.data_sources import (
+    DataSource,
+    MultiEntitySource,
+    resolve_source,
+)
+
+
+class DummySource(DataSource):
+    def get_attribute(self, name):
+        return []
+
+    def __len__(self):
+        return 0
+
+
+class DummyMultiSource(MultiEntitySource):
+    def __init__(self, entity_types):
+        self._entity_types = entity_types
+        self._sources = {et: DummySource() for et in entity_types}
+
+    def keys(self):
+        return iter(self._entity_types)
+
+    def __getitem__(self, entity_type):
+        if entity_type not in self._sources:
+            raise KeyError(entity_type)
+        return self._sources[entity_type]
+
+    def __contains__(self, entity_type):
+        return entity_type in self._sources
+
+
+class TestResolveSource:
+    def test_resolve_normal_source(self):
+        source = DummySource()
+        result = resolve_source("my_source", {"my_source": source})
+        assert result is source
+
+    def test_resolve_dot_notation(self):
+        multi = DummyMultiSource(["nodes", "edges"])
+        result = resolve_source("network.nodes", {"network": multi})
+        assert result is multi["nodes"]
+
+    def test_missing_source_raises_value_error(self):
+        with pytest.raises(ValueError, match="not available"):
+            resolve_source("missing", {})
+
+    def test_missing_base_in_dot_notation_raises_value_error(self):
+        with pytest.raises(ValueError, match="not available"):
+            resolve_source("missing.nodes", {})
+
+    def test_dot_on_non_multi_raises_type_error(self):
+        source = DummySource()
+        with pytest.raises(TypeError, match="not a multi-entity source"):
+            resolve_source("src.nodes", {"src": source})
+
+    def test_invalid_entity_type_raises_value_error(self):
+        multi = DummyMultiSource(["nodes"])
+        with pytest.raises(ValueError, match="not found in source"):
+            resolve_source("network.bogus", {"network": multi})
+
+    def test_bare_multi_source_raises_type_error(self):
+        multi = DummyMultiSource(["nodes", "edges"])
+        with pytest.raises(TypeError, match="multi-entity source"):
+            resolve_source("network", {"network": multi})
+
+    def test_bare_multi_source_error_lists_available_types(self):
+        multi = DummyMultiSource(["nodes", "edges"])
+        with pytest.raises(TypeError, match="edges, nodes"):
+            resolve_source("network", {"network": multi})

--- a/packages/simulation-core/tests/preprocessing/test_resolve_source.py
+++ b/packages/simulation-core/tests/preprocessing/test_resolve_source.py
@@ -55,7 +55,7 @@ class TestResolveSource:
 
     def test_dot_on_non_multi_raises_type_error(self):
         source = DummySource()
-        with pytest.raises(TypeError, match="not a multi-entity source"):
+        with pytest.raises(TypeError, match="not a MultipleEntityTypeSource"):
             resolve_source("src.nodes", {"src": source})
 
     def test_invalid_entity_type_raises_value_error(self):

--- a/packages/simulation-core/tests/preprocessing/test_resolve_source.py
+++ b/packages/simulation-core/tests/preprocessing/test_resolve_source.py
@@ -1,10 +1,10 @@
-"""Tests for resolve_source and MultiEntitySource."""
+"""Tests for resolve_source and MultipleEntityTypeSource."""
 
 import pytest
 
 from movici_simulation_core.preprocessing.data_sources import (
     DataSource,
-    MultiEntitySource,
+    MultipleEntityTypeSource,
     resolve_source,
 )
 
@@ -17,7 +17,7 @@ class DummySource(DataSource):
         return 0
 
 
-class DummyMultiSource(MultiEntitySource):
+class DummyMultiSource(MultipleEntityTypeSource):
     def __init__(self, entity_types):
         self._entity_types = entity_types
         self._sources = {et: DummySource() for et in entity_types}


### PR DESCRIPTION
## Summary
- Adds `INPSource`, a new `DataSource` for reading EPANET INP files via WNTR
- Supports all six entity types: junctions, tanks, reservoirs, pipes, pumps, valves
- Includes geometry extraction (points for nodes, linestrings for links) and model caching
- Integrates with `DatasetCreator` via the `"inp"` source type
- Adds `wntr` as an explicit dependency

## Test plan
- [x] Unit tests for all entity types, attributes, geometry, bounding box, caching
- [x] Integration tests with `DatasetCreator` including ID linking
- [ ] Verify with a real-world INP file