### PR TITLE
UV: always sync all packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
         os: ${{ matrix.os }}
 
     - name: Install
-      run: uv sync --group dev --frozen
+      run: uv sync --all-packages --group dev --frozen
 
     - name: Run tests
       run: |

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,7 @@ jobs:
         os: ${{ matrix.os }}
 
     - name: Install
-      run: uv sync --group dev --frozen
+      run: uv sync --all-packages --group dev --frozen
 
     - name: Run tests
       run: |
@@ -82,7 +82,7 @@ jobs:
         os: ${{ matrix.os }}
 
     - name: Install
-      run: uv sync --group dev --frozen
+      run: uv sync --all-packages --group dev --frozen
 
     - name: Run tests with Numba JIT enabled
       run: |
@@ -111,7 +111,7 @@ jobs:
         os: ${{ matrix.os }}
 
     - name: Install
-      run: uv sync --group dev
+      run: uv sync --all-packages --group dev --frozen
 
     - name: Run tests with coverage
       run: |
@@ -137,7 +137,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-          uv sync --all-groups
+          uv sync --all-packages --all-groups --frozen
 
     - name: Test docs
       run: |

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+sync:
+	uv sync --all-packages --all-groups
+
 ruff:
 	uv run ruff format --check
 	uv run ruff check

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,10 @@ Then you can install this package and all its dependencies using uv:
 
 .. code-block::
 
-  uv sync --all-groups
+  uv sync --all-packages --all-groups
+
+  # This command is also availble from the Makefile
+  make sync
 
   # optional: activate the virtual environment
   source .venv/bin/activate


### PR DESCRIPTION
Describe your changes
--------------------

When running uv sync for development, we should always include all packages to ensure that we install the correct (dev) dependencies

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to
 re-/sublicense my contribution
