### PR TITLE
Introduce movici-data-core and implement Repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-/build/
-/dist/
-/*.egg-info/
+**/build/
+**/dist/
+**/*.egg-info/
 pip-wheel-metadata/
 
 # ide project settings

--- a/packages/data-core/Makefile
+++ b/packages/data-core/Makefile
@@ -1,0 +1,18 @@
+MODULE_NAME = movici_data_core
+
+unittest:
+	NUMBA_DISABLE_JIT=1 uv run pytest -v tests/
+
+coverage:
+	NUMBA_DISABLE_JIT=1 uv run pytest \
+		--cov $(MODULE_NAME) \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		--cov-report=html \
+		tests/
+
+test-numba:
+	uv run pytest -v tests/
+
+mypy:
+	- mypy src/$(MODULE_NAME)

--- a/packages/data-core/README.rst
+++ b/packages/data-core/README.rst
@@ -1,0 +1,16 @@
+Movici Data Core
+======================
+
+Copyright 2026ff NGinfra
+
+Movici is a set of tools and software for performing simulations geospatial entities.
+
+Movici Data Core is a supporting library that holds the data and domain model for a Movici
+database. It is developed SQLAlchemy.
+
+Installation
+------------
+
+.. code-block::
+
+  pip install movici-data-core

--- a/packages/data-core/pyproject.toml
+++ b/packages/data-core/pyproject.toml
@@ -37,10 +37,11 @@ dependencies = [
   "movici-simulation-core",
   "marshmallow>=4.3.0",
 ]
+[project.optional-dependencies]
+sqlite = ["aiosqlite>=0.22.1"]
 
 [dependency-groups]
 dev = ["pytest-asyncio>=1.3.0"]
-sqlite = ["aiosqlite>=0.22.1"]
 
 [project.urls]
 Homepage = "https://github.com/nginfra/movici-simulation-core"

--- a/packages/data-core/pyproject.toml
+++ b/packages/data-core/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
+
+[project]
+name = "movici-data-core"
+dynamic = ["version"]
+description = "Shared library for reading/writing movici data using SQL databases"
+readme = "README.rst"
+requires-python = ">=3.10,<3.14"
+license = { text = "Movici Public License" }
+authors = [{ name = "NGinfra Movici", email = "movici@nginfra.nl" }]
+maintainers = [{ name = "NGinfra - Movici", email = "movici@nginfra.nl" }]
+classifiers = [
+  "Development Status :: 2 - Pre-Alpha",
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Developers",
+  "License :: Free for non-commercial use",
+  "License :: Other/Proprietary License",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Scientific/Engineering",
+  "Topic :: Database",
+]
+
+dependencies = [
+  "fastapi[standard]",
+  "svcs",
+  "numpy",
+  "orjson>=3.11.7",
+  "sqlalchemy",
+  "movici-simulation-core",
+  "marshmallow>=4.3.0",
+]
+
+[dependency-groups]
+dev = ["pytest-asyncio>=1.3.0"]
+sqlite = ["aiosqlite>=0.22.1"]
+
+[project.urls]
+Homepage = "https://github.com/nginfra/movici-simulation-core"
+Documentation = "https://docs.movici.nl/en/latest/index.html"
+Repository = "https://github.com/nginfra/movici-simulation-core"
+Issues = "https://github.com/nginfra/movici-simulation-core/issues"
+
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+fallback-version = "0.0.0"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto" # work with regular async @pytest.fixtures
+
+[tool.mypy]
+warn_return_any = true
+warn_unused_configs = true
+show_error_context = true
+follow_untyped_imports = true

--- a/packages/data-core/pyproject.toml
+++ b/packages/data-core/pyproject.toml
@@ -29,13 +29,10 @@ classifiers = [
 ]
 
 dependencies = [
-  "fastapi[standard]",
-  "svcs",
   "numpy",
   "orjson>=3.11.7",
   "sqlalchemy",
   "movici-simulation-core",
-  "marshmallow>=4.3.0",
 ]
 [project.optional-dependencies]
 sqlite = ["aiosqlite>=0.22.1"]

--- a/packages/data-core/src/movici_data_core/database/backend.py
+++ b/packages/data-core/src/movici_data_core/database/backend.py
@@ -3,15 +3,11 @@ from __future__ import annotations
 import contextlib
 import dataclasses
 import pathlib
-import typing as t
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from movici_data_core.exceptions import (
-    InconsistentDatabase,
-    InvalidAction,
-)
+from movici_data_core.exceptions import InvalidAction
 from movici_simulation_core import EntityInitDataFormat
 from movici_simulation_core.types import ExternalSerializationStrategy
 
@@ -20,7 +16,6 @@ from .general import (
     create_default_scenario,
     create_default_workspace,
     get_engine,
-    get_options,
     initialize_database,
 )
 from .repository import SQLAlchemyRepository
@@ -63,18 +58,6 @@ class SQLAlchemyServer:
         async with self.session_factory(**(session_kwargs or {})) as session:
             yield session
 
-    @contextlib.asynccontextmanager
-    async def get_backend(self, session_kwargs: dict[str, t.Any] | None = None):
-        async with self.get_session(**(session_kwargs or {})) as session:
-            options = await get_options(session)
-            try:
-                yield await self._with_serializer(self._build_backend(session, options))
-            except Exception:
-                await session.rollback()
-                raise
-            else:
-                await session.commit()
-
     async def setup_db(self, mode: db.DatabaseMode = db.DatabaseMode.SINGLE_SCENARIO):
         async with self.engine.begin() as conn:
             await conn.run_sync(db.Base.metadata.create_all)
@@ -82,35 +65,6 @@ class SQLAlchemyServer:
         async with self.session_factory() as session:
             await initialize_database(session, mode)
             await session.commit()
-
-    def _build_backend(self, session: AsyncSession, options: db.Options):
-        backend = SQLAlchemyBackend(session, options, tmpfile_dir=self.tmpfile_dir)
-        if options.mode == db.DatabaseMode.MULTIPLE_WORKSPACES:
-            return backend
-
-        if (workspace_id := options.default_workspace_id) is None:
-            raise InconsistentDatabase("a default workspace is required")
-
-        if options.mode == db.DatabaseMode.SINGLE_WORKSPACE:
-            return dataclasses.replace(
-                backend, workspace_id=workspace_id, single_workspace_mode=True
-            )
-        if options.mode == db.DatabaseMode.SINGLE_SCENARIO:
-            if (scenario_id := options.default_scenario_id) is None:
-                raise InconsistentDatabase("a default scenario is required")
-            return dataclasses.replace(
-                backend,
-                workspace_id=workspace_id,
-                scenario_id=scenario_id,
-                single_workspace_mode=True,
-                single_scenario_mode=True,
-            )
-
-        assert False, f"Unknown database mode {options.mode}"
-
-    async def _with_serializer(self, backend: SQLAlchemyBackend):
-        schema = await backend.attribute_types.as_schema()
-        return dataclasses.replace(backend, serializer=self.serializer_cls(schema))
 
 
 @dataclasses.dataclass

--- a/packages/data-core/src/movici_data_core/database/backend.py
+++ b/packages/data-core/src/movici_data_core/database/backend.py
@@ -220,7 +220,7 @@ class SQLAlchemyBackend:
         :param strict_entity_types: set/unset the ``STRICT_ENTITY_TYPES`` option, which governs
           whether to automatically create non-existing entity types when they are encountered in an
           uploaded dataset
-        :param attributes: set/unset the ``STRICT_ATTRIBUTES`` option, which governs whether
+        :param attributes: set/unset the ``STRICT_ATTRIBUTE_TYPES`` option, which governs whether
           to automatically create non-existing attribute types when they are encountered in an
           uploaded dataset
         :param strict_model_types: set/unset the ``STRICT_MODEL_TYPES`` option, which governs
@@ -235,7 +235,7 @@ class SQLAlchemyBackend:
         if strict_entity_types is not None:
             self.options.STRICT_ENTITY_TYPES = strict_entity_types
         if strict_attributes is not None:
-            self.options.STRICT_ATTRIBUTES = strict_attributes
+            self.options.STRICT_ATTRIBUTE_TYPES = strict_attributes
         if strict_model_types is not None:
             self.options.STRICT_MODEL_TYPES = strict_model_types
         if strict_scenario_datasets is not None:

--- a/packages/data-core/src/movici_data_core/database/backend.py
+++ b/packages/data-core/src/movici_data_core/database/backend.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import pathlib
+import typing as t
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from movici_data_core.exceptions import (
+    InconsistentDatabase,
+    InvalidAction,
+)
+from movici_simulation_core import EntityInitDataFormat
+from movici_simulation_core.types import ExternalSerializationStrategy
+
+from . import model as db
+from .general import (
+    create_default_scenario,
+    create_default_workspace,
+    get_engine,
+    get_options,
+    initialize_database,
+)
+from .repository import SQLAlchemyRepository
+
+
+class SQLAlchemyServer:
+    """This class is responsible for building a ``SQLAlchemyBackend``. When running inside an
+    FastAPI application, this class has the same lifetime as the application. From this class,
+    request-scoped ``SQLAlchemyBackend`` instances are created.
+
+    :param dbapi_url: a DB API url string
+    :param serializer_cls: a class for instantiating an ``ExternalSerializationStrategy``. Default:
+      ``EntityInitDataFormat``
+    :param tmpfile_dir: a path to a directory that may be used to store temporary files
+    """
+
+    session_factory: async_sessionmaker[AsyncSession]
+    engine: AsyncEngine
+
+    def __init__(
+        self,
+        dbapi_url: str,
+        serializer_cls: type[ExternalSerializationStrategy] = EntityInitDataFormat,
+        tmpfile_dir: pathlib.Path | None = None,
+    ):
+
+        self.dbapi_url = dbapi_url
+        self.serializer_cls = serializer_cls
+        self.tmpfile_dir = tmpfile_dir
+
+    @contextlib.asynccontextmanager
+    async def begin(self, **engine_kwargs):
+        async with get_engine(self.dbapi_url, **engine_kwargs) as engine:
+            self.engine = engine
+            self.session_factory = async_sessionmaker(engine)
+            yield self
+
+    @contextlib.asynccontextmanager
+    async def get_session(self, **session_kwargs):
+        async with self.session_factory(**(session_kwargs or {})) as session:
+            yield session
+
+    @contextlib.asynccontextmanager
+    async def get_backend(self, session_kwargs: dict[str, t.Any] | None = None):
+        async with self.get_session(**(session_kwargs or {})) as session:
+            options = await get_options(session)
+            try:
+                yield await self._with_serializer(self._build_backend(session, options))
+            except Exception:
+                await session.rollback()
+                raise
+            else:
+                await session.commit()
+
+    async def setup_db(self, mode: db.DatabaseMode = db.DatabaseMode.SINGLE_SCENARIO):
+        async with self.engine.begin() as conn:
+            await conn.run_sync(db.Base.metadata.create_all)
+
+        async with self.session_factory() as session:
+            await initialize_database(session, mode)
+            await session.commit()
+
+    def _build_backend(self, session: AsyncSession, options: db.Options):
+        backend = SQLAlchemyBackend(session, options, tmpfile_dir=self.tmpfile_dir)
+        if options.mode == db.DatabaseMode.MULTIPLE_WORKSPACES:
+            return backend
+
+        if (workspace_id := options.default_workspace_id) is None:
+            raise InconsistentDatabase("a default workspace is required")
+
+        if options.mode == db.DatabaseMode.SINGLE_WORKSPACE:
+            return dataclasses.replace(
+                backend, workspace_id=workspace_id, single_workspace_mode=True
+            )
+        if options.mode == db.DatabaseMode.SINGLE_SCENARIO:
+            if (scenario_id := options.default_scenario_id) is None:
+                raise InconsistentDatabase("a default scenario is required")
+            return dataclasses.replace(
+                backend,
+                workspace_id=workspace_id,
+                scenario_id=scenario_id,
+                single_workspace_mode=True,
+                single_scenario_mode=True,
+            )
+
+        assert False, f"Unknown database mode {options.mode}"
+
+    async def _with_serializer(self, backend: SQLAlchemyBackend):
+        schema = await backend.attribute_types.as_schema()
+        return dataclasses.replace(backend, serializer=self.serializer_cls(schema))
+
+
+@dataclasses.dataclass
+class SQLAlchemyBackend:
+    session: AsyncSession
+    options: db.Options
+    serializer: ExternalSerializationStrategy | None = None
+    workspace_id: UUID | None = None
+    scenario_id: UUID | None = None
+    single_scenario_mode: bool = False
+    single_workspace_mode: bool = False
+
+    tmpfile_dir: pathlib.Path | None = None
+
+    @property
+    def repository(self):
+        return SQLAlchemyRepository(
+            self.session, self.options, self.workspace_id, self.scenario_id
+        )
+
+    def for_workspace(self, workspace_id: UUID):
+        return dataclasses.replace(self, workspace_id=workspace_id)
+
+    def for_scenario(self, scenario_id: UUID):
+        return dataclasses.replace(self, scenario_id=scenario_id)
+
+    async def set_database_mode(self, new_mode: db.DatabaseMode):
+        """Change the mode of this database. Upgrading is always possible along the path
+        ``SINGLE_SCENARIO`` -> ``SINGLE_WORKSPACE`` -> ``MULTIPLE_WORKSPACES``. Downgrading is only
+        possible if a single workspace and/or scenario currently exists in the database
+
+        :param new_mode: the new database mode
+        """
+        current_mode = self.options.mode
+        if current_mode == new_mode:
+            return
+
+        match (current_mode, new_mode):
+            case (db.DatabaseMode.MULTIPLE_WORKSPACES, db.DatabaseMode.SINGLE_SCENARIO):
+                await self._downgrade_to_single_workspace_mode()
+                await self._downgrade_to_single_scenario_mode()
+            case (db.DatabaseMode.SINGLE_SCENARIO, db.DatabaseMode.MULTIPLE_WORKSPACES):
+                await self._upgrade_to_single_workspace_mode()
+                await self._upgrade_to_multiple_workspaces_mode()
+            case (db.DatabaseMode.MULTIPLE_WORKSPACES, db.DatabaseMode.SINGLE_WORKSPACE):
+                await self._downgrade_to_single_workspace_mode()
+            case (db.DatabaseMode.SINGLE_WORKSPACE, db.DatabaseMode.MULTIPLE_WORKSPACES):
+                await self._upgrade_to_multiple_workspaces_mode()
+            case (db.DatabaseMode.SINGLE_WORKSPACE, db.DatabaseMode.SINGLE_SCENARIO):
+                await self._downgrade_to_single_scenario_mode()
+            case (db.DatabaseMode.SINGLE_SCENARIO, db.DatabaseMode.SINGLE_WORKSPACE):
+                await self._upgrade_to_single_workspace_mode()
+
+    async def _upgrade_to_single_workspace_mode(self):
+        self.options.default_scenario = None
+        self.single_scenario_mode = False
+
+    async def _upgrade_to_multiple_workspaces_mode(self):
+        self.options.default_workspace = None
+        self.single_workspace_mode = False
+
+    async def _downgrade_to_single_scenario_mode(self):
+        scenarios = await self.repository.scenarios.list()
+        if len(scenarios) > 1:
+            raise InvalidAction(
+                "Cannot downgrade to SINGLE_SCENARIO mode when multiple scenarios exist"
+            )
+        elif len(scenarios) == 1:
+            scenario_id = scenarios[0].id
+        else:
+            if self.workspace_id is None:
+                raise ValueError("workspace_id must be set")
+            scenario_id = await create_default_scenario(self.session, self.workspace_id)
+        self.options.mode = db.DatabaseMode.SINGLE_SCENARIO
+        self.options.default_scenario_id = scenario_id
+        self.single_scenario_mode = True
+        self.scenario_id = scenario_id
+
+    async def _downgrade_to_single_workspace_mode(self):
+        workspaces = await self.repository.workspaces.list()
+        if len(workspaces) > 1:
+            raise InvalidAction(
+                "Cannot downgrade to SINGLE_WORKSPACE mode when multiple workspaces exist"
+            )
+        elif len(workspaces) == 1:
+            workspace_id = workspaces[0].id
+        else:
+            workspace_id = await create_default_workspace(self.session)
+        self.options.mode = db.DatabaseMode.SINGLE_WORKSPACE
+        self.options.default_workspace_id = workspace_id
+        self.single_workspace_mode = True
+        self.workspace_id = workspace_id
+
+    def set_options(
+        self,
+        strict_dataset_types: bool | None = None,
+        strict_entity_types: bool | None = None,
+        strict_attributes: bool | None = None,
+        strict_model_types: bool | None = None,
+        strict_scenario_datasets: bool | None = None,
+    ):
+        """Set various database options for the database
+
+        :param strict_dataset_types: set/unset the ``STRICT_DATASET_TYPES`` option, which governs
+          whether to automatically create non-existing dataset types when they are encountered in
+          an uploaded dataset
+        :param strict_entity_types: set/unset the ``STRICT_ENTITY_TYPES`` option, which governs
+          whether to automatically create non-existing entity types when they are encountered in an
+          uploaded dataset
+        :param attributes: set/unset the ``STRICT_ATTRIBUTES`` option, which governs whether
+          to automatically create non-existing attribute types when they are encountered in an
+          uploaded dataset
+        :param strict_model_types: set/unset the ``STRICT_MODEL_TYPES`` option, which governs
+          whether to automatically create non-existing model types when they are encountered in an
+          uploaded scenario config
+        :param strict_scenario_datasets: set/unset the ``STRICT_SCENARIO_DATASETS`` option, which
+          governs whether to automatically create stubs for non-existing datasets when they are
+          encountered in an uploaded scenario config
+        """
+        if strict_dataset_types is not None:
+            self.options.STRICT_DATASET_TYPES = strict_dataset_types
+        if strict_entity_types is not None:
+            self.options.STRICT_ENTITY_TYPES = strict_entity_types
+        if strict_attributes is not None:
+            self.options.STRICT_ATTRIBUTES = strict_attributes
+        if strict_model_types is not None:
+            self.options.STRICT_MODEL_TYPES = strict_model_types
+        if strict_scenario_datasets is not None:
+            self.options.STRICT_SCENARIO_DATASETS = strict_scenario_datasets

--- a/packages/data-core/src/movici_data_core/database/db_types.py
+++ b/packages/data-core/src/movici_data_core/database/db_types.py
@@ -1,0 +1,86 @@
+import datetime
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import JSON, DateTime
+from sqlalchemy.dialects.mssql import UNIQUEIDENTIFIER
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.types import CHAR, TypeDecorator
+
+
+class GUID(TypeDecorator):
+    """Platform-independent GUID type.
+
+    Uses PostgreSQL's UUID type or MSSQL's UNIQUEIDENTIFIER,
+    otherwise uses CHAR(32), storing as stringified hex values.
+
+    source: https://docs.sqlalchemy.org/en/20/core/custom_types.html#backend-agnostic-guid-type
+    """
+
+    impl = CHAR
+    cache_ok = True
+
+    _default_type = CHAR(36)
+
+    def load_dialect_impl(self, dialect):
+        if dialect.name == "postgresql":
+            return dialect.type_descriptor(UUID())
+        elif dialect.name == "mssql":
+            return dialect.type_descriptor(UNIQUEIDENTIFIER())
+        else:
+            return dialect.type_descriptor(self._default_type)
+
+    def process_bind_param(self, value, dialect):
+        if value is None or dialect.name in ("postgresql", "mssql"):
+            return value
+        else:
+            if not isinstance(value, uuid.UUID):
+                value = uuid.UUID(value)
+            return str(value)
+
+    def process_result_value(self, value, dialect):
+        if value is None:
+            return value
+        else:
+            if not isinstance(value, uuid.UUID):
+                value = uuid.UUID(value)
+            return value
+
+
+class TZDateTime(TypeDecorator):
+    impl = DateTime
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            if not value.tzinfo or value.tzinfo.utcoffset(value) is None:
+                raise TypeError("tzinfo is required")
+            value = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = value.replace(tzinfo=datetime.timezone.utc)
+        return value
+
+
+class JSONTuple(TypeDecorator):
+    impl = JSON
+    cache_ok = True
+
+    def __init__(self, *args, length: int | None = None, **kwargs):
+        self.length = length
+        super().__init__(*args, **kwargs)
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            if not isinstance(value, Sequence):
+                raise TypeError("must be a sequence")
+            if self.length is not None and len(value) != self.length:
+                raise TypeError(f"must be of length {self.length}")
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            value = tuple(value)
+        return value

--- a/packages/data-core/src/movici_data_core/database/general.py
+++ b/packages/data-core/src/movici_data_core/database/general.py
@@ -122,7 +122,7 @@ def _default_flags(mode: DatabaseMode):
     """Return a dictionary of default flags that must be set (to true), based on the ``mode``"""
     if mode == DatabaseMode.MULTIPLE_WORKSPACES:
         return {
-            "STRICT_ATTRIBUTES": True,
+            "STRICT_ATTRIBUTE_TYPES": True,
             "STRICT_DATASET_TYPES": True,
             "STRICT_ENTITY_TYPES": True,
             "STRICT_MODEL_TYPES": True,

--- a/packages/data-core/src/movici_data_core/database/general.py
+++ b/packages/data-core/src/movici_data_core/database/general.py
@@ -1,4 +1,5 @@
 import contextlib
+import dataclasses
 import typing as t
 from uuid import UUID
 
@@ -16,7 +17,7 @@ from movici_data_core.database.model import (
     Scenario,
     Workspace,
 )
-from movici_data_core.domain_model import ScenarioStatus
+from movici_data_core.domain_model import ScenarioStatus, SimulationInfo
 from movici_data_core.exceptions import DatabaseAlreadyInitialized, DatabaseNotYetInitialized
 
 
@@ -92,7 +93,7 @@ async def create_default_scenario(
                 display_name=display_name,
                 description="",
                 status=ScenarioStatus.READY,
-                simulation_info={},
+                simulation_info=dataclasses.asdict(SimulationInfo.default()),
                 epsg_code=0,
             )
         ),

--- a/packages/data-core/src/movici_data_core/database/general.py
+++ b/packages/data-core/src/movici_data_core/database/general.py
@@ -1,0 +1,130 @@
+import contextlib
+import typing as t
+from uuid import UUID
+
+from sqlalchemy import event, func, insert, select, text, update
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import joinedload
+
+from movici_data_core.database.model import (
+    DEFAULT_SCENARIO_NAME,
+    DEFAULT_SCHEMA_VERSION,
+    DEFAULT_WORKSPACE_NAME,
+    DatabaseMode,
+    Metadata,
+    Options,
+    Scenario,
+    Workspace,
+)
+from movici_data_core.domain_model import ScenarioStatus
+from movici_data_core.exceptions import DatabaseAlreadyInitialized, DatabaseNotYetInitialized
+
+
+@contextlib.asynccontextmanager
+async def get_engine(dbapi_url: str, **kwargs):
+    engine = create_async_engine(dbapi_url, **kwargs)
+
+    if "sqlite" in dbapi_url:
+        # enable foreign keys for every sqlite connection
+        @event.listens_for(engine.sync_engine, "engine_connect")
+        def engine_connect(conn):
+            with conn.begin():
+                conn.execute(text("PRAGMA foreign_keys=ON"))
+
+    yield engine
+    await engine.dispose()
+
+
+async def initialize_database(session: AsyncSession, mode: DatabaseMode):
+    metadata_count = (await session.scalar(select(func.count(Metadata.id)))) or 0
+    options_count = (await session.scalar(select(func.count(Options.id)))) or 0
+
+    if metadata_count > 0 or options_count > 0:
+        raise DatabaseAlreadyInitialized
+    await session.execute(insert(Metadata).values(id=1, version=DEFAULT_SCHEMA_VERSION))
+
+    workspace_id = None
+    scenario_id = None
+    if mode in (DatabaseMode.SINGLE_SCENARIO, DatabaseMode.SINGLE_WORKSPACE):
+        workspaces_count = (await session.scalar(select(func.count(Options.id)))) or 0
+        if workspaces_count > 0:
+            raise DatabaseAlreadyInitialized
+
+        workspace_id = await create_default_workspace(session)
+        if mode == DatabaseMode.SINGLE_SCENARIO:
+            scenario_id = await create_default_scenario(session, workspace_id)
+
+    await session.execute(
+        insert(Options).values(
+            default_workspace_id=workspace_id,
+            default_scenario_id=scenario_id,
+            mode=mode,
+            **_default_flags(mode),
+        )
+    )
+
+
+async def create_default_workspace(
+    session: AsyncSession, name=DEFAULT_WORKSPACE_NAME, display_name=DEFAULT_WORKSPACE_NAME
+) -> UUID:
+    return t.cast(
+        UUID,
+        await session.scalar(
+            insert(Workspace).returning(Workspace.id).values(name=name, display_name=display_name)
+        ),
+    )
+
+
+async def create_default_scenario(
+    session: AsyncSession,
+    workspace_id: UUID,
+    name=DEFAULT_SCENARIO_NAME,
+    display_name=DEFAULT_SCENARIO_NAME,
+) -> UUID:
+    return t.cast(
+        UUID,
+        await session.scalar(
+            insert(Scenario)
+            .returning(Scenario.id)
+            .values(
+                workspace_id=workspace_id,
+                name=name,
+                display_name=display_name,
+                description="",
+                status=ScenarioStatus.READY,
+                simulation_info={},
+                epsg_code=0,
+            )
+        ),
+    )
+
+
+async def get_version(session: AsyncSession):
+    metadata = await session.get(Metadata, 1)
+    if not metadata:
+        raise DatabaseNotYetInitialized
+    return metadata.version
+
+
+async def get_options(session: AsyncSession):
+    options = await session.get(Options, 1, options=[joinedload(Options.default_workspace)])
+    if not options:
+        raise DatabaseNotYetInitialized
+    return options
+
+
+async def set_options(session: AsyncSession, **options):
+    await session.execute(update(Options).values(**options))
+
+
+def _default_flags(mode: DatabaseMode):
+    """Return a dictionary of default flags that must be set (to true), based on the ``mode``"""
+    if mode == DatabaseMode.MULTIPLE_WORKSPACES:
+        return {
+            "STRICT_ATTRIBUTES": True,
+            "STRICT_DATASET_TYPES": True,
+            "STRICT_ENTITY_TYPES": True,
+            "STRICT_MODEL_TYPES": True,
+            "STRICT_SCENARIO_DATASETS": True,
+        }
+    return {}

--- a/packages/data-core/src/movici_data_core/database/model.py
+++ b/packages/data-core/src/movici_data_core/database/model.py
@@ -100,7 +100,7 @@ class Options(Base):
 
     STRICT_DATASET_TYPES: Mapped[bool] = mapped_column(default=False)
     STRICT_ENTITY_TYPES: Mapped[bool] = mapped_column(default=False)
-    STRICT_ATTRIBUTES: Mapped[bool] = mapped_column(default=False)
+    STRICT_ATTRIBUTE_TYPES: Mapped[bool] = mapped_column(default=False)
     STRICT_MODEL_TYPES: Mapped[bool] = mapped_column(default=False)
     STRICT_SCENARIO_DATASETS: Mapped[bool] = mapped_column(default=False)
 

--- a/packages/data-core/src/movici_data_core/database/model.py
+++ b/packages/data-core/src/movici_data_core/database/model.py
@@ -445,6 +445,7 @@ class Update(Base):
             model_type=self.model_type.name,
             timestamp=self.timestamp,
             iteration=self.iteration,
+            created_at=self.created_at,
         )
 
 

--- a/packages/data-core/src/movici_data_core/database/model.py
+++ b/packages/data-core/src/movici_data_core/database/model.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import datetime
+import enum
+import typing as t
+import uuid
+
+import numpy as np
+from sqlalchemy import (
+    JSON,
+    ForeignKey,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from movici_data_core import domain_model
+from movici_data_core.domain_model import BoundingBox, DatasetFormat, ScenarioStatus
+from movici_simulation_core.core import DataType
+
+from .db_types import GUID, JSONTuple, TZDateTime
+
+T_dom = t.TypeVar("T_dom", covariant=True)
+
+
+class NamedResource(t.Protocol[T_dom]):
+    id: Mapped[uuid.UUID]
+    name: Mapped[str]
+
+    def to_domain(self) -> T_dom: ...
+
+
+def to_domain_or_none(obj: NamedResource[T_dom] | None) -> T_dom | None:
+    return obj.to_domain() if obj is not None else None
+
+
+class Base(DeclarativeBase):
+    type_annotation_map = {
+        uuid.UUID: GUID,
+        datetime.datetime: TZDateTime,
+        tuple: JSONTuple,
+        dict: JSON,
+    }
+
+
+class DatabaseMode(enum.Enum):
+    """Mode in which this database (file) runs.
+
+    - ``SINGLE_SCENARIO``: This database contains a single scenario including init data and
+      possibly updates
+    - ``SINGLE_WORKSPACE``: This database may contain multiple scenarios but all scenarios belong
+      to a single workspace
+    - ``MULTIPLE_WORKSPACES``: This database may contain multiple workspace, each containing their
+      own scenarios, datasets and simulation results
+    """
+
+    SINGLE_SCENARIO = "single_scenario"
+    SINGLE_WORKSPACE = "single_workspace"
+    MULTIPLE_WORKSPACES = "multiple_workspaces"
+
+
+class AttributeDataType(enum.Enum):
+    BOOL = "bool"
+    INT = "int"
+    FLOAT = "float"
+    STR = "str"
+
+
+DEFAULT_SCHEMA_VERSION = "v1"
+DEFAULT_WORKSPACE_NAME = "__default__"
+DEFAULT_SCENARIO_NAME = "default_scenario"
+
+
+DEFAULT_NAME_MAX_LENGTH = 50
+DEFAULT_DISPLAY_NAME_MAX_LENGTH = 50
+
+ATTRIBUTE_NAME_MAX_LENGTH = 100
+ATTRIBUTE_UNIT_MAX_LENGTH = 20
+ATTRIBUTE_ENUM_NAME_MAX_LENGTH = 20
+
+
+class Metadata(Base):
+    __tablename__ = "metadata"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    version: Mapped[str] = mapped_column(String(64))
+
+
+class Options(Base):
+    __tablename__ = "options"
+    id: Mapped[int] = mapped_column(primary_key=True)
+    mode: Mapped[DatabaseMode]
+
+    STRICT_DATASET_TYPES: Mapped[bool] = mapped_column(default=False)
+    STRICT_ENTITY_TYPES: Mapped[bool] = mapped_column(default=False)
+    STRICT_ATTRIBUTES: Mapped[bool] = mapped_column(default=False)
+    STRICT_MODEL_TYPES: Mapped[bool] = mapped_column(default=False)
+    STRICT_SCENARIO_DATASETS: Mapped[bool] = mapped_column(default=False)
+
+    default_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("workspace.id", ondelete="RESTRICT")
+    )
+    default_scenario_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("scenario.id", ondelete="RESTRICT")
+    )
+    default_workspace: Mapped[Workspace | None] = relationship()
+    default_scenario: Mapped[Scenario | None] = relationship()
+
+
+class Workspace(Base):
+    __tablename__ = "workspace"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH), unique=True)
+    display_name: Mapped[str] = mapped_column(String(DEFAULT_DISPLAY_NAME_MAX_LENGTH))
+    datasets: Mapped[list[Dataset]] = relationship(back_populates="workspace")
+    scenarios: Mapped[list[Scenario]] = relationship(back_populates="workspace")
+
+    def to_domain(self) -> domain_model.Workspace:
+        return domain_model.Workspace(id=self.id, name=self.name, display_name=self.display_name)
+
+
+class DatasetType(Base):
+    __tablename__ = "dataset_type"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH), unique=True)
+    format: Mapped[DatasetFormat]
+    mimetype: Mapped[str | None]
+
+    def to_domain(self) -> domain_model.DatasetType:
+        return domain_model.DatasetType(
+            id=self.id, name=self.name, format=self.format, mimetype=self.mimetype
+        )
+
+
+class Dataset(Base):
+    __tablename__ = "dataset"
+    __table_args__ = (UniqueConstraint("workspace_id", "name"),)
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("workspace.id", ondelete="CASCADE"))
+    workspace: Mapped[Workspace] = relationship(back_populates="datasets")
+
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH))
+    display_name: Mapped[str] = mapped_column(String(DEFAULT_DISPLAY_NAME_MAX_LENGTH))
+
+    dataset_type_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset_type.id", ondelete="RESTRICT")
+    )
+    dataset_type: Mapped[DatasetType] = relationship(DatasetType)
+
+    general: Mapped[dict | None] = mapped_column(JSON)
+    epsg_code: Mapped[int | None]
+    bounding_box: Mapped[tuple[float, float, float, float] | None] = mapped_column(
+        JSONTuple(length=4)
+    )
+
+    created_at: Mapped[datetime.datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime.datetime] = mapped_column(default=func.now(), onupdate=func.now())
+
+    def to_domain(
+        self, has_raw_data: bool = False, has_attributes: bool = False
+    ) -> domain_model.Dataset:
+        return domain_model.Dataset(
+            id=self.id,
+            name=self.name,
+            display_name=self.display_name,
+            dataset_type=self.dataset_type.to_domain(),
+            workspace=self.workspace.to_domain(),
+            general=self.general,
+            epsg_code=self.epsg_code,
+            bounding_box=(
+                BoundingBox(*self.bounding_box) if self.bounding_box else BoundingBox.empty()
+            ),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+            has_data=has_raw_data or has_attributes,
+        )
+
+
+class EntityType(Base):
+    __tablename__ = "entity_type"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH), unique=True)
+
+    def to_domain(self) -> domain_model.EntityType:
+        return domain_model.EntityType(name=self.name, id=self.id)
+
+
+class AttributeType(Base):
+    __tablename__ = "attribute_type"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(ATTRIBUTE_NAME_MAX_LENGTH), unique=True)
+    has_rowptr: Mapped[bool]
+    unit_type: Mapped[AttributeDataType]
+    unit_shape: Mapped[tuple[int, ...]] = mapped_column(JSONTuple)
+    unit: Mapped[str] = mapped_column(String(ATTRIBUTE_UNIT_MAX_LENGTH))
+    description: Mapped[str]
+    enum_name: Mapped[str | None] = mapped_column(String(ATTRIBUTE_ENUM_NAME_MAX_LENGTH))
+
+    @property
+    def data_type(self):
+        py_type = {
+            AttributeDataType.BOOL: bool,
+            AttributeDataType.INT: int,
+            AttributeDataType.FLOAT: float,
+            AttributeDataType.STR: str,
+        }[self.unit_type]
+        return DataType(py_type, unit_shape=self.unit_shape, csr=self.has_rowptr)
+
+    def to_domain(self) -> domain_model.AttributeType:
+        return domain_model.AttributeType(
+            id=self.id,
+            name=self.name,
+            data_type=self.data_type,
+            unit=self.unit,
+            description=self.description,
+            enum_name=self.enum_name,
+        )
+
+
+class DataArray(Base):
+    __tablename__ = "data_array"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    dtype: Mapped[str] = mapped_column(String(20))
+    shape: Mapped[tuple] = mapped_column(JSON)
+    data: Mapped[bytes]
+
+    min_val: Mapped[float | None]
+    max_val: Mapped[float | None]
+
+    attribute_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("attribute.id", ondelete="CASCADE"))
+    attribute: Mapped[Attribute] = relationship(back_populates="data")
+
+    def to_numpy(self) -> np.ndarray:
+        """Reconstruct numpy array from stored data.
+
+        :return: Reconstructed NumPy array
+        """
+        return np.frombuffer(self.data, dtype=self.dtype).reshape(self.shape)
+
+
+class RowptrArray(Base):
+    __tablename__ = "rowptr_array"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    data: Mapped[bytes]
+
+    attribute_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("attribute.id", ondelete="CASCADE"))
+    attribute: Mapped[Attribute] = relationship(back_populates="rowptr")
+
+    def to_numpy(self) -> np.ndarray:
+        """Reconstruct numpy array from stored data.
+
+        :return: Reconstructed NumPy array
+        """
+        return np.frombuffer(self.data, dtype=int)
+
+
+class Attribute(Base):
+    __tablename__ = "attribute"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    entity_type_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("entity_type.id", ondelete="RESTRICT")
+    )
+    attribute_type_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("attribute_type.id", ondelete="RESTRICT")
+    )
+    length: Mapped[int]
+    entity_type: Mapped[EntityType] = relationship()
+    attribute_type: Mapped[AttributeType] = relationship()
+    data: Mapped[DataArray] = relationship()
+    rowptr: Mapped[RowptrArray | None] = relationship()
+
+
+class DatasetAttribute(Base):
+    __tablename__ = "dataset_attribute"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    dataset_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("dataset.id", ondelete="CASCADE"))
+    attribute_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("attribute.id", ondelete="CASCADE"))
+
+    dataset: Mapped[Dataset] = relationship()
+    attribute: Mapped[Attribute] = relationship()
+
+
+class RawData(Base):
+    __tablename__ = "raw_data"
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    dataset_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("dataset.id", ondelete="CASCADE"))
+    encoding: Mapped[str | None]
+    compresion: Mapped[str | None]
+
+
+class RawDataChunk(Base):
+    __tablename__ = "raw_data_chunk"
+    __table_args__ = (UniqueConstraint("raw_data_id", "sequence"),)
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    raw_data_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("raw_data.id", ondelete="CASCADE"))
+    sequence: Mapped[int]
+    bytes: Mapped[bytes]
+
+
+class ModelType(Base):
+    __tablename__ = "model_type"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH), unique=True)
+    jsonschema: Mapped[dict] = mapped_column(JSON)
+
+    def to_domain(self) -> domain_model.ModelType:
+        return domain_model.ModelType(id=self.id, name=self.name, jsonschema=self.jsonschema)
+
+
+class Scenario(Base):
+    __tablename__ = "scenario"
+    __table_args__ = (UniqueConstraint("workspace_id", "name"),)
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("workspace.id", ondelete="CASCADE"))
+    workspace: Mapped[Workspace] = relationship(back_populates="scenarios")
+
+    name: Mapped[str]
+    display_name: Mapped[str]
+    description: Mapped[str] = mapped_column(Text)
+    status: Mapped[ScenarioStatus]
+
+    simulation_info: Mapped[dict] = mapped_column(JSON)
+
+    epsg_code: Mapped[int]
+
+    created_at: Mapped[datetime.datetime] = mapped_column(default=func.now())
+    updated_at: Mapped[datetime.datetime] = mapped_column(default=func.now(), onupdate=func.now())
+
+    datasets: Mapped[list[ScenarioDataset]] = relationship()
+    models: Mapped[list[ScenarioModel]] = relationship()
+
+    def to_domain(self) -> domain_model.Scenario:
+        return domain_model.Scenario(
+            id=self.id,
+            workspace=self.workspace.to_domain(),
+            name=self.name,
+            display_name=self.display_name,
+            description=self.description,
+            simulation_info=self.simulation_info,
+            epsg_code=self.epsg_code,
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+class ScenarioDataset(Base):
+    __tablename__ = "scenario_dataset"
+    __table_args__ = (UniqueConstraint("scenario_id", "sequence"),)
+    scenario_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("scenario.id", ondelete="CASCADE"), primary_key=True
+    )
+    dataset_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("dataset.id", ondelete="RESTRICT"), primary_key=True
+    )
+    sequence: Mapped[int] = mapped_column()
+    scenario: Mapped[Scenario] = relationship(Scenario, back_populates="datasets")
+    dataset: Mapped[Dataset] = relationship(Dataset)
+
+
+class ScenarioModel(Base):
+    __tablename__ = "scenario_model"
+    __table_args__ = (
+        UniqueConstraint("scenario_id", "sequence"),
+        UniqueConstraint("scenario_id", "name"),
+    )
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH))
+    scenario_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("scenario.id", ondelete="CASCADE"))
+    model_type_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("model_type.id", ondelete="RESTRICT")
+    )
+    sequence: Mapped[int]
+    config: Mapped[dict]
+    references: Mapped[list[ScenarioModelReference]] = relationship()
+
+    model_type: Mapped[ModelType] = relationship()
+
+
+class ScenarioModelReference(Base):
+    __tablename__ = "scenario_model_reference"
+    __table_args__ = (UniqueConstraint("scenario_model_id", "path"),)
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    scenario_model_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("scenario_model.id", ondelete="CASCADE")
+    )
+    path: Mapped[str]
+    dataset_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("dataset.id", ondelete="RESTRICT")
+    )
+    entity_type_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("entity_type.id", ondelete="RESTRICT")
+    )
+    attribute_type_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("attribute_type.id", ondelete="RESTRICT")
+    )
+    dataset: Mapped[Dataset] = relationship()
+    entity_type: Mapped[EntityType] = relationship()
+    attribute_type: Mapped[AttributeType] = relationship()
+
+
+class Update(Base):
+    __tablename__ = "update"
+    __table_args__ = (UniqueConstraint("scenario_id", "timestamp", "iteration"),)
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    scenario_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("scenario.id", ondelete="CASCADE"))
+    dataset_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("dataset.id", ondelete="RESTRICT"))
+    model_type_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("model_type.id", ondelete="RESTRICT")
+    )
+
+    # For the model name we could link to the associated ScenarioModel. However, any
+    # changes to the scenario would recreate all ScenarioModels, which would break this link.
+    # Instead, we denormalize model_name and store a copy directly in the Update
+    # table
+    model_name: Mapped[str] = mapped_column(String(DEFAULT_NAME_MAX_LENGTH))
+
+    timestamp: Mapped[int]
+    iteration: Mapped[int]
+    created_at: Mapped[datetime.datetime] = mapped_column(default=func.now())
+
+    scenario: Mapped[Scenario] = relationship()
+    dataset: Mapped[Dataset] = relationship()
+    model_type: Mapped[ModelType] = relationship()
+
+    def to_domain(self) -> domain_model.Update:
+        return domain_model.Update(
+            id=self.id,
+            dataset=domain_model.ScenarioDataset(
+                self.dataset.name, self.dataset.dataset_type.name, id=self.dataset_id
+            ),
+            model_name=self.model_name,
+            model_type=self.model_type.name,
+            timestamp=self.timestamp,
+            iteration=self.iteration,
+        )
+
+
+class UpdateAttribute(Base):
+    __tablename__ = "update_attribute"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    update_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("update.id", ondelete="CASCADE"))
+    attribute_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("attribute.id", ondelete="CASCADE"))
+
+    update: Mapped[Update] = relationship()
+    attribute: Mapped[Attribute] = relationship()

--- a/packages/data-core/src/movici_data_core/database/model.py
+++ b/packages/data-core/src/movici_data_core/database/model.py
@@ -17,7 +17,12 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from movici_data_core import domain_model
-from movici_data_core.domain_model import BoundingBox, DatasetFormat, ScenarioStatus
+from movici_data_core.domain_model import (
+    BoundingBox,
+    DatasetFormat,
+    ScenarioStatus,
+    SimulationInfo,
+)
 from movici_simulation_core.core import DataType
 
 from .db_types import GUID, JSONTuple, TZDateTime
@@ -344,7 +349,7 @@ class Scenario(Base):
             name=self.name,
             display_name=self.display_name,
             description=self.description,
-            simulation_info=self.simulation_info,
+            simulation_info=SimulationInfo(**self.simulation_info),
             epsg_code=self.epsg_code,
             created_at=self.created_at,
             updated_at=self.updated_at,

--- a/packages/data-core/src/movici_data_core/database/model.py
+++ b/packages/data-core/src/movici_data_core/database/model.py
@@ -87,6 +87,11 @@ ATTRIBUTE_ENUM_NAME_MAX_LENGTH = 20
 
 
 class Metadata(Base):
+    """A table that should contain a single entry with the schema version of this database. Future
+    iterations of the data-core may use this version to determine compatibility or migrate data
+    from one version to another
+    """
+
     __tablename__ = "metadata"
 
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -94,6 +99,31 @@ class Metadata(Base):
 
 
 class Options(Base):
+    """A table that should contain a single entry with a database's options. It contains the
+    database mode (see :class:`DatabaseMode`) and the various ``STRICT_`` options:
+
+    - ``STRICT_DATASET_TYPES``: when set, datasets may only be added to this database if their
+      dataset_type exists. If unset, a dataset type will be created with format
+      ``DatasetFormat.ENTITY_BASED`` if a dataset is about to be added with a non-exsiting type
+    - ``STRICT_ENTITY_TYPES``: when set, an entity type must exist before data for an entity group
+      of that type can be added in either a dataset or an update. When unset, an entity type will
+      be created when adding data for an entity group of a non-existing type
+    - ``STRICT_ATTRIBUTE_TYPES``: when set, an attribute type must exist before an entity group
+      can contain data for that attribute. When unset, an attribute type will be created with an
+      inferred data type when storing attribute data for that type.
+    - ``STRICT_MODEL_TYPES``: when set, a model type must exist before a scenario can be added that
+      uses a model of that type. When unset, a model type will be created when adding a scenario
+      that uses a model of that type. It will be created with a pass-all schema so that any config
+      is allowed, but this also means that no references to datasets, entity groups or attributes
+      can be made in the model config
+    - ``STRICT_SCENARIO_DATASETS``: when set, every dataset in a scenario config ``"dataset"``
+      section must exist before the scenario config may be added. When unset, any a stub for every
+      dataset that does not exist will be added when adding a scenario config
+
+    Furthermore, the options singleton contains a reference to the default scenario and/or default
+    workspace if they exist (determined by the database mode mode)
+    """
+
     __tablename__ = "options"
     id: Mapped[int] = mapped_column(primary_key=True)
     mode: Mapped[DatabaseMode]

--- a/packages/data-core/src/movici_data_core/database/repository/__init__.py
+++ b/packages/data-core/src/movici_data_core/database/repository/__init__.py
@@ -1,0 +1,91 @@
+import dataclasses
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..model import Options
+from .dataset import DatasetDataRepository, DatasetRepository
+from .general import (
+    AttributeTypeRepository,
+    DatasetTypeRepository,
+    EntityTypeRepository,
+    ModelTypeRepository,
+)
+from .scenario import ScenarioRepository
+from .updates import UpdateRepository
+from .workspace import WorkspaceRepository
+
+
+@dataclasses.dataclass
+class SQLAlchemyRepository:
+    session: AsyncSession
+    options: Options
+    workspace_id: UUID | None = None
+    scenario_id: UUID | None = None
+
+    def for_workspace(self, workspace_id: UUID | None):
+        if workspace_id is None:
+            raise ValueError("A workspace id must be given")
+        return dataclasses.replace(self, workspace_id=workspace_id)
+
+    def for_scenario(self, scenario_id: UUID):
+        return dataclasses.replace(self, scenario_id=scenario_id)
+
+    # define these fields as properties to prevent cyclic references and simplify GC
+    @property
+    def workspaces(self):
+        return WorkspaceRepository(self.session, self.options, self)
+
+    @property
+    def dataset_types(self):
+        return DatasetTypeRepository(self.session, self.options, self)
+
+    @property
+    def entity_types(self):
+        return EntityTypeRepository(self.session, self.options, self)
+
+    @property
+    def attribute_types(self):
+        return AttributeTypeRepository(self.session, self.options, self)
+
+    @property
+    def model_types(self):
+        return ModelTypeRepository(self.session, self.options, self)
+
+    @property
+    def datasets(self):
+        return DatasetRepository(self.session, self.options, self, workspace_id=self.workspace_id)
+
+    @property
+    def dataset_data(self):
+        return DatasetDataRepository(self.session, self.options, self)
+
+    @property
+    def scenarios(self):
+        return ScenarioRepository(
+            self.session,
+            self.options,
+            self,
+            workspace_id=self.workspace_id,
+            scenario_id=self.scenario_id,
+        )
+
+    @property
+    def updates(self):
+        if self.scenario_id is None:
+            raise ValueError("SQLAlchemyRepository.scenario_id must be set")
+        return UpdateRepository(self.session, self.options, self, scenario_id=self.scenario_id)
+
+
+__all__ = [
+    "DatasetDataRepository",
+    "DatasetRepository",
+    "AttributeTypeRepository",
+    "DatasetTypeRepository",
+    "EntityTypeRepository",
+    "ModelTypeRepository",
+    "ScenarioRepository",
+    "UpdateRepository",
+    "WorkspaceRepository",
+    "SQLAlchemyRepository",
+]

--- a/packages/data-core/src/movici_data_core/database/repository/__init__.py
+++ b/packages/data-core/src/movici_data_core/database/repository/__init__.py
@@ -18,17 +18,43 @@ from .workspace import WorkspaceRepository
 
 @dataclasses.dataclass
 class SQLAlchemyRepository:
+    r"""SQLAlchemyRepository contains the collection of ``SQLResourceRepository``\s that are the
+    repositories for the various resources. A SQLAlchemyRepository can be tied to a specific
+    workspace or scenario, which is relevant for the `datasets`, `scenarios` and `updates`
+    repositories.
+
+    :param session: a SQLAlchemy async session
+    :param options: the current database :class:`Options`
+    :param workspace_id: an optional workspace UUID
+    :param scenario_id: an optional scenario UUID
+    """
+
     session: AsyncSession
     options: Options
     workspace_id: UUID | None = None
     scenario_id: UUID | None = None
 
-    def for_workspace(self, workspace_id: UUID | None):
-        if workspace_id is None:
-            raise ValueError("A workspace id must be given")
+    def for_workspace(self, workspace_id: UUID):
+        """Bind the repository to a specific workspace. This is generally done automatically by the
+        :class:`SQLAlchemyBackend` managing this repository. A SQLAlchemyRepository must be bound
+        to a specific workspace for operations on Datasets, Scenarios and Updates
+
+        :param workspace_id: the Workspace UUID to bind the repository to
+        :return: a copy of the SQLAlchemyRepository bound to the workspace. The original repository
+            remains in tact
+        """
         return dataclasses.replace(self, workspace_id=workspace_id)
 
     def for_scenario(self, scenario_id: UUID):
+        """Bind the repository to a specific scenario. This is generally done automatically by the
+        :class:`SQLAlchemyBackend` managing this repository. A SQLAlchemyRepository must be bound
+        to a specific scenario for operations that require a specific scenario, such as retrieving,
+        updating or deleting a Scenario.
+
+        :param scenario_id: the Scenario UUID to bind the repository to
+        :return: a copy of the SQLAlchemyRepository bound to the scenario. The original repository
+            remains in tact
+        """
         return dataclasses.replace(self, scenario_id=scenario_id)
 
     # define these fields as properties to prevent cyclic references and simplify GC

--- a/packages/data-core/src/movici_data_core/database/repository/common.py
+++ b/packages/data-core/src/movici_data_core/database/repository/common.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import contextlib
+import dataclasses
+import functools
+import io
+import pathlib
+import typing as t
+from uuid import UUID
+
+import numpy as np
+import orjson
+from sqlalchemy import Insert, Select, delete, exists, insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from movici_data_core.database import model as db
+from movici_data_core.database.model import NamedResource, Options, to_domain_or_none
+from movici_data_core.domain_model import AttributeType, DatasetData, EntityType
+from movici_data_core.exceptions import ResourceDoesNotExist
+from movici_simulation_core.core import DataType, get_rowptr, infer_data_type_from_array
+from movici_simulation_core.core.schema import DEFAULT_ROWPTR_KEY
+from movici_simulation_core.types import DatasetData as NumpyDatasetData
+from movici_simulation_core.types import NumpyAttributeData
+
+if t.TYPE_CHECKING:
+    from . import SQLAlchemyRepository
+T_dom = t.TypeVar("T_dom")
+
+
+@dataclasses.dataclass
+class SQLResourceRepository:
+    """Base class for the various resource repositories"""
+
+    session: AsyncSession
+    options: Options
+    all_data: SQLAlchemyRepository
+
+    async def _exists(self, *where) -> bool:
+        return bool(await self.session.scalar(select(exists().where(*where))))
+
+
+def ensure_valid_id(method):
+    """Decorator to ensure that a resource id exists, raises ResourceDoesNotExist if a non-existing
+    id is given
+    :param method: a method from a GenericResourceRepository that takes in ``id`` as its first
+    argument
+    """
+
+    @functools.wraps(method)
+    async def _wrapped(self: GenericResourceRepository, id: UUID, *args, **kwargs):
+        if (await self.get_by_id(id)) is None:
+            raise ResourceDoesNotExist(self.__resource_type_name__, id=id)
+        return await method(self, id, *args, **kwargs)
+
+    return _wrapped
+
+
+class GenericResourceRepository(SQLResourceRepository, t.Generic[T_dom]):
+    """A GenericResourceRepository is the simplest CRUD repository. Resources are globally unique
+    by name and do not have a parent (such as a Workspace). Resources that are managed through
+    a GenericResourceRepository are:
+
+    * Workspaces
+    * DatasetTypes
+    * EntityTypes
+    * AttributeTypes
+    * ModelTypes
+    """
+
+    __resource__: type[NamedResource[T_dom]]
+    __resource_type_name__: str
+
+    async def list(self) -> list[T_dom]:
+        result = await self.session.scalars(select(self.__resource__))
+        return [obj.to_domain() for obj in result]
+
+    async def exists(self, name: str) -> bool:
+        return await self._exists(self.__resource__.name == name)
+
+    async def get_by_name(self, name: str) -> T_dom | None:
+        return to_domain_or_none(
+            await self.session.scalar(
+                select(self.__resource__).where(self.__resource__.name == name).limit(1)
+            )
+        )
+
+    async def get_by_id(self, id: UUID) -> T_dom | None:
+        return to_domain_or_none(await self.session.get(self.__resource__, id))
+
+    @ensure_valid_id
+    async def delete(self, id: UUID):
+        await self.session.execute(delete(self.__resource__).where(self.__resource__.id == id))
+
+    async def create(self, obj: T_dom) -> UUID:
+        raise NotImplementedError
+
+    async def update(self, id: UUID, obj: T_dom) -> None:
+        raise NotImplementedError
+
+
+class EntityDataSelector(t.Protocol):
+    """EntityDataSelector is a Protocol that EntityDataProcessor uses to retrieve SQLAlchemy
+    queries for the resource it is operating on, ie Dataset or Update.
+    """
+
+    def select_linked_attribute(self, id: UUID) -> Select[tuple[db.Attribute]]: ...
+    def insert_linked_attribute(self, id: UUID, attribute_id: UUID) -> Insert: ...
+
+
+class EntityDataProcessor:
+    """Logic for storing and retrieving entity data from the database. This can be used for both
+    Dataset data and Update data"""
+
+    def __init__(
+        self, session: AsyncSession, all_data: SQLAlchemyRepository, selector: EntityDataSelector
+    ):
+        self.session = session
+        self.all_data = all_data
+        self.selector = selector
+
+    async def get(self, id: UUID) -> NumpyDatasetData:
+        result: NumpyDatasetData = {}
+        for attribute in (
+            await self.session.scalars(
+                self.selector.select_linked_attribute(id).options(
+                    joinedload(db.Attribute.rowptr),
+                    joinedload(db.Attribute.data),
+                    joinedload(db.Attribute.entity_type),
+                    joinedload(db.Attribute.attribute_type),
+                )
+            )
+        ).all():
+            entity_group = result.setdefault(attribute.entity_type.name, {})
+            attr_data: NumpyAttributeData = {"data": attribute.data.to_numpy()}
+            if attribute.rowptr is not None:
+                attr_data[DEFAULT_ROWPTR_KEY] = attribute.rowptr.to_numpy()
+            entity_group[attribute.attribute_type.name] = attr_data
+        return result
+
+    async def store(self, id: UUID, data: NumpyDatasetData):
+        """
+        :param id: dataset UUID
+        :param data: dataset data section in numpy format
+        """
+        for entity_group, attributes in data.items():
+            entity_type = await self.all_data.entity_types.ensure_entity_type(
+                EntityType(entity_group)
+            )
+            for attr_name, attr_data in attributes.items():
+                data_type = infer_data_type_from_array(t.cast(dict, attr_data))
+                attribute_type = await self.all_data.attribute_types.ensure_attribute_type(
+                    AttributeType(attr_name, data_type=data_type)
+                )
+
+                data_array: np.ndarray = attr_data["data"]
+                rowptr = get_rowptr(t.cast(dict, attr_data))
+
+                attribute_id = await self.session.scalar(
+                    insert(db.Attribute)
+                    .values(
+                        entity_type_id=entity_type.id,
+                        attribute_type_id=attribute_type.id,
+                        length=len(data_array) if rowptr is None else len(rowptr) - 1,
+                    )
+                    .returning(db.Attribute.id)
+                )
+                assert attribute_id is not None
+
+                await self._store_data_array(data_array, attribute_id, data_type=data_type)
+
+                if rowptr is not None:
+                    await self._store_rowptr_array(rowptr, attribute_id)
+
+                await self.session.execute(
+                    self.selector.insert_linked_attribute(id=id, attribute_id=attribute_id)
+                )
+
+    async def _store_data_array(self, arr: np.ndarray, attribute_id: UUID, data_type: DataType):
+        min_val, max_val = data_type.get_min_max(arr)
+        await self.session.execute(
+            insert(db.DataArray).values(
+                attribute_id=attribute_id,
+                dtype=arr.dtype.str,
+                shape=arr.shape,
+                data=arr.tobytes(),
+                min_val=min_val,
+                max_val=max_val,
+            )
+        )
+
+    async def _store_rowptr_array(self, arr: np.ndarray, attribute_id: UUID):
+        await self.session.execute(
+            insert(db.RowptrArray).values(data=arr.tobytes(), attribute_id=attribute_id)
+        )
+
+
+class RawDataProcessor:
+    """Logic for storing dataset data as raw bytes in the database. Used for ``BINARY`` and
+    ``UNSTRUCTURED`` datasets
+    """
+
+    RAW_DATA_CHUNK_SIZE = 100_000_000  # 100 MB
+
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(
+        self, id: UUID | None = None, raw_data: db.RawData | None = None
+    ) -> tuple[str | None, bytearray]:
+        result = bytearray()
+        encoding, gen = await self.stream_bytes(id, raw_data)
+        async for chunk in gen:
+            result += chunk
+        return encoding, result
+
+    async def stream_bytes(
+        self, id: UUID | None = None, raw_data: db.RawData | None = None, yield_per=1
+    ) -> tuple[str | None, t.AsyncGenerator[bytes]]:
+        """
+        :returns: a tuple (encoding, bytestreamer). The bytestreamer can be used as an async
+            generator
+        """
+        if not ((id is None) ^ (raw_data is None)):
+            raise ValueError("Supply one of id and raw_data, but not both")
+
+        raw_data = raw_data or await self._ensure_raw_data(t.cast(UUID, id))
+
+        async def _bytestreamer():
+            async for chunk in await self.session.stream_scalars(
+                select(db.RawDataChunk.bytes)
+                .execution_options(yield_per=yield_per)
+                .where(db.RawDataChunk.raw_data_id == raw_data.id)
+                .order_by(db.RawDataChunk.sequence.asc())
+            ):
+                yield chunk
+
+        return raw_data.encoding, _bytestreamer()
+
+    async def get_dict(self, id: UUID) -> dict:
+        raw_data = await self._ensure_raw_data(id)
+        if raw_data.encoding != "json":
+            raise ValueError(f"Expected dataset encoding 'json', got {raw_data.encoding}")
+        _, raw_bytes = await self.get(raw_data=raw_data)
+        return t.cast(dict, orjson.loads(raw_bytes))
+
+    async def store(self, id: UUID, data: DatasetData, chunk_size=0):
+        chunk_size = chunk_size or self.RAW_DATA_CHUNK_SIZE
+        with self._data_as_bytesio(data) as (encoding, raw_reader):
+            raw_data_id = t.cast(
+                UUID,
+                await self.session.scalar(
+                    insert(db.RawData)
+                    .values(
+                        dataset_id=id,
+                        encoding=encoding,
+                    )
+                    .returning(db.RawData.id)
+                ),
+            )
+            for seq, chunk in self._raw_data_chunks(raw_reader, chunk_size):
+                await self.session.execute(
+                    insert(db.RawDataChunk).values(
+                        raw_data_id=raw_data_id, sequence=seq, bytes=chunk
+                    )
+                )
+
+    async def _ensure_raw_data(self, id: UUID) -> db.RawData:
+        raw_data = await self.session.scalar(
+            select(db.RawData).where(db.RawData.dataset_id == id).limit(1)
+        )
+        if raw_data is None:
+            raise ResourceDoesNotExist("dataset_data", id=id)
+        return raw_data
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _data_as_bytesio(data: DatasetData):
+        encoding = None
+        finalizer = None
+        if isinstance(data, dict):
+            data = orjson.dumps(data)
+            encoding = "json"
+        if isinstance(data, bytes):
+            data = io.BytesIO(data)
+        if isinstance(data, pathlib.Path):
+            data = open(data, "rb")
+            finalizer = data.close
+
+        try:
+            yield encoding, data
+        finally:
+            if finalizer is not None:
+                finalizer()
+
+    @staticmethod
+    def _raw_data_chunks(file: t.BinaryIO, chunk_size: int):
+        if chunk_size <= 0:
+            raise ValueError("Chunk size must be greater than 0")
+        seq = 0
+        while chunk := file.read(chunk_size):
+            seq += 1
+            yield seq, chunk

--- a/packages/data-core/src/movici_data_core/database/repository/common.py
+++ b/packages/data-core/src/movici_data_core/database/repository/common.py
@@ -36,6 +36,7 @@ class SQLResourceRepository:
     options: Options
     all_data: SQLAlchemyRepository
 
+    # TODO: make this a function `resource_exists` that takes a session instead of a method
     async def _exists(self, *where) -> bool:
         return bool(await self.session.scalar(select(exists().where(*where))))
 
@@ -66,6 +67,10 @@ class GenericResourceRepository(SQLResourceRepository, t.Generic[T_dom]):
     * EntityTypes
     * AttributeTypes
     * ModelTypes
+
+    To implement a GenericResourceRepository, subclass it and set the ``__resource__`` and
+    ``__resource_type_name__`` class fields. Then, implement the ``create`` and ``update`` methods
+    it is recommended to wrap the ``update`` method in an ``@ensure_valid_id`` decorator
     """
 
     __resource__: type[NamedResource[T_dom]]
@@ -218,7 +223,7 @@ class RawDataProcessor:
         self, id: UUID | None = None, raw_data: db.RawData | None = None, yield_per=1
     ) -> tuple[str | None, t.AsyncGenerator[bytes]]:
         """
-        :returns: a tuple (encoding, bytestreamer). The bytestreamer can be used as an async
+        :return: a tuple (encoding, bytestreamer). The bytestreamer can be used as an async
             generator
         """
         if not ((id is None) ^ (raw_data is None)):

--- a/packages/data-core/src/movici_data_core/database/repository/dataset.py
+++ b/packages/data-core/src/movici_data_core/database/repository/dataset.py
@@ -71,6 +71,12 @@ class DatasetRepository(SQLResourceRepository):
         ).options(joinedload(db.Dataset.workspace), joinedload(db.Dataset.dataset_type))
 
     async def exists(self, name: str):
+        """return whether the dataset (by name) already exists in the database for the acitve
+        workspace.
+
+        :param name: dataset name
+        :return: a boolean indicating the dataset exists for the active workspace
+        """
         workspace_id = self._ensure_workspace_id()
         return await self._exists(db.Dataset.workspace_id == workspace_id, db.Dataset.name == name)
 
@@ -84,7 +90,16 @@ class DatasetRepository(SQLResourceRepository):
             ds.to_domain(has_data_raw, has_attributes) for ds, has_data_raw, has_attributes in rows
         ]
 
-    async def get_one_with_has_data(self, where_clause: ColumnElement[bool]):
+    async def get_by_name(self, name: str) -> Dataset | None:
+        workspace_id = self._ensure_workspace_id()
+        return await self._get_one_with_has_data(
+            (db.Dataset.workspace_id == workspace_id) & (db.Dataset.name == name)
+        )
+
+    async def get_by_id(self, id: UUID) -> Dataset | None:
+        return await self._get_one_with_has_data(db.Dataset.id == id)
+
+    async def _get_one_with_has_data(self, where_clause: ColumnElement[bool]):
         result = (
             await self.session.execute(self.selector_with_has_data.where(where_clause).limit(1))
         ).first()
@@ -94,20 +109,16 @@ class DatasetRepository(SQLResourceRepository):
         ds, has_raw_data, has_attributes = result
         return ds.to_domain(has_raw_data, has_attributes)
 
-    async def get_by_name(self, name: str) -> Dataset | None:
-        workspace_id = self._ensure_workspace_id()
-        return await self.get_one_with_has_data(
-            (db.Dataset.workspace_id == workspace_id) & (db.Dataset.name == name)
-        )
-
-    async def get_by_id(self, id: UUID) -> Dataset | None:
-        return await self.get_one_with_has_data(db.Dataset.id == id)
-
     async def delete(self, id: UUID):
         await self.all_data.dataset_data.delete(id)
         await self.session.execute(delete(db.Dataset).where(db.Dataset.id == id))
 
     async def get_summary(self, id: UUID):
+        """Request a DatasetSummary for the dataset id
+
+        :param id: the dataset id
+        :return: A ``DatasetSummary``
+        """
         dataset = await self.get_by_id(id)
         if dataset is None:
             raise ResourceDoesNotExist("dataset", id=id)
@@ -183,16 +194,36 @@ class DatasetRepository(SQLResourceRepository):
         )
 
     async def update(self, id: UUID, obj: Dataset):
+        """Update a :class:`Dataset` in the database when not providing a full dataset with data
+
+        Valid fields to update are: ``name``, ``display_name``
+
+        :param id: the UUID of the stored ``Dataset``
+        :param obj: the ``Dataset`` object with the changes
+        """
         current = await self.get_by_id(id)
         if current is None:
             raise ResourceDoesNotExist("dataset", id=id)
+        # TODO: accept changes to dataset type if the dataset does not have data and is not used
+        #  anywhere?
         await self.session.execute(
             update(db.Dataset)
             .where(db.Dataset.id == id)
             .values(name=obj.name, display_name=obj.display_name)
         )
 
+    # TODO: merge update_with_data with regular update and switch on whether data is provided
     async def update_with_data(self, id: UUID, obj: Dataset, chunk_size=0):
+        """Update a dataset when providing a full dataset with data, processes all fields, except
+        the data section, which must be processed separately using the
+        :class:`DatasetDataRepository`.
+
+        :param id: the UUID of the stored ``Dataset``
+        :param obj: the ``Dataset`` object with the changes
+        :param chunk_size: the chunk size in bytes when storing unstructured or binary data. When
+            set to 0, the default, the chunk size is set to
+            :attr:`RawDataProcessor.RAW_DATA_CHUNK_SIZE`
+        """
         current = await self.get_by_id(id)
         if current is None:
             raise ResourceDoesNotExist("dataset", id=id)
@@ -222,6 +253,16 @@ class DatasetRepository(SQLResourceRepository):
     async def ensure_scenario_datasets(
         self, datasets: t.Sequence[ScenarioDataset]
     ) -> t.List[ScenarioDataset]:
+        r"""Ensure that the :class:`Dataset`s of a sequences of :class:`ScenarioDataset`\s exist in
+        the database or raise an error. If one or more of the ``Dataset``s do not exist and the
+        database option ``STRICT_SCENARIO_DATASETS`` is unset, the non-existing datasets will be
+        created. If the ``STRICT_MODEL_TYPES`` options is set, an error is raised instead. An
+        error is also raised if a ``Dataset`` already exists but with a different dataset type
+
+        :param datasets: The ``ScenarioDataset``s to ensure
+        :return: The datasets as they exist in the database, as ``ScenarioDataset`` objects, in
+            the same order as the input sequence
+        """
         workspace_id = self._ensure_workspace_id()
         existing_datasets = {
             ds.name: t.cast(db.Dataset, ds)
@@ -277,20 +318,42 @@ class DatasetRepository(SQLResourceRepository):
 
 class DatasetDataRepository(SQLResourceRepository):
     async def exists_for(self, id: UUID):
+        """
+        :param id: a dataset id
+        :return: a boolean wether the dataset has data (either entity data or raw data)
+        """
         raw_data_exists = await self._exists(db.RawData.dataset_id == id)
         entity_data_exists = await self._exists(db.DatasetAttribute.dataset_id == id)
         return raw_data_exists or entity_data_exists
 
-    def stream_binary_data(
-        self, id: UUID, yield_per=1
-    ) -> t.Coroutine[None, None, tuple[str | None, t.AsyncGenerator[bytes]]]:
-        return RawDataProcessor(self.session).stream_bytes(id, yield_per=yield_per)
+    async def stream_binary_data(self, id: UUID, yield_per=1) -> t.AsyncGenerator[bytes]:
+        """
+        :param id: the dataset ``UUID``
+        :param yield_per: an optimzation parameter for the database to request n chunks at a time.
+            Default: 1
 
-    def get_unstructured_data(self, id: UUID):
-        return RawDataProcessor(self.session).get_dict(id)
+        :return: An async generator that can be iterated over (async for loop) to produce
+            chunks of binary data. The chunk size is determined by the data stored in the database
+            and is :attr:`RawDataProcessor.RAW_DATA_CHUNK_SIZE` by default
+        """
+        _, generator = await RawDataProcessor(self.session).stream_bytes(id, yield_per=yield_per)
+        return generator
 
-    def get_entity_data(self, id: UUID):
-        return EntityDataProcessor(
+    async def get_unstructured_data(self, id: UUID) -> dict:
+        """return the dataset data for an ``UNSTRUCTURED`` dataset
+
+        :param id: the dataset ``UUID``
+        :return: The unstructured dataset data section
+        """
+        return await RawDataProcessor(self.session).get_dict(id)
+
+    async def get_entity_data(self, id: UUID):
+        """return the dataset data for an ``ENTITY_BASED`` dataset
+
+        :param id: the dataset ``UUID``
+        :return: The entity based dataset data section
+        """
+        return await EntityDataProcessor(
             self.session, all_data=self.all_data, selector=DatasetDataSelector()
         ).get(id)
 

--- a/packages/data-core/src/movici_data_core/database/repository/dataset.py
+++ b/packages/data-core/src/movici_data_core/database/repository/dataset.py
@@ -127,7 +127,7 @@ class DatasetRepository(SQLResourceRepository):
         attribute: db.Attribute
         for attribute, min_val, max_val in await self.session.execute(
             select(db.Attribute, db.DataArray.min_val, db.DataArray.max_val)
-            .join(db.Attribute)
+            .join(db.DataArray, db.DataArray.attribute_id == db.Attribute.id)
             .join(db.DatasetAttribute)
             .options(
                 joinedload(db.Attribute.attribute_type),

--- a/packages/data-core/src/movici_data_core/database/repository/dataset.py
+++ b/packages/data-core/src/movici_data_core/database/repository/dataset.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import dataclasses
+import typing as t
+from uuid import UUID
+
+import sqlalchemy.exc
+from sqlalchemy import (
+    ColumnElement,
+    Insert,
+    Select,
+    delete,
+    exists,
+    insert,
+    select,
+    update,
+)
+from sqlalchemy.orm import joinedload
+
+from movici_data_core.database import model as db
+from movici_data_core.domain_model import (
+    AttributeSummary,
+    Dataset,
+    DatasetData,
+    DatasetFormat,
+    DatasetSummary,
+    DatasetType,
+    EntityGroupSummary,
+    ScenarioDataset,
+)
+from movici_data_core.exceptions import (
+    InvalidAction,
+    InvalidResource,
+    ResourceAlreadyExists,
+    ResourceDoesNotExist,
+    map_errors,
+)
+
+from .common import (
+    EntityDataProcessor,
+    EntityDataSelector,
+    RawDataProcessor,
+    SQLResourceRepository,
+)
+
+
+@dataclasses.dataclass
+class DatasetRepository(SQLResourceRepository):
+    workspace_id: UUID | None = None
+
+    def _ensure_workspace_id(self) -> UUID:
+        if self.workspace_id is None:
+            raise ValueError("DatasetRepository.workspace_id is required")
+        return self.workspace_id
+
+    @property
+    def selector(self):
+        workspace_id = self._ensure_workspace_id()
+        return (
+            select(db.Dataset)
+            .where(db.Dataset.workspace_id == workspace_id)
+            .options(joinedload(db.Dataset.workspace), joinedload(db.Dataset.dataset_type))
+        )
+
+    @property
+    def selector_with_has_data(self):
+        return select(
+            db.Dataset,
+            exists().where(db.RawData.dataset_id == db.Dataset.id),
+            exists().where(db.DatasetAttribute.dataset_id == db.Dataset.id),
+        ).options(joinedload(db.Dataset.workspace), joinedload(db.Dataset.dataset_type))
+
+    async def exists(self, name: str):
+        workspace_id = self._ensure_workspace_id()
+        return await self._exists(db.Dataset.workspace_id == workspace_id, db.Dataset.name == name)
+
+    async def list(self) -> list[Dataset]:
+        workspace_id = self._ensure_workspace_id()
+        rows = await self.session.execute(
+            self.selector_with_has_data.where(db.Dataset.workspace_id == workspace_id)
+        )
+
+        return [
+            ds.to_domain(has_data_raw, has_attributes) for ds, has_data_raw, has_attributes in rows
+        ]
+
+    async def get_one_with_has_data(self, where_clause: ColumnElement[bool]):
+        result = (
+            await self.session.execute(self.selector_with_has_data.where(where_clause).limit(1))
+        ).first()
+
+        if result is None:
+            return None
+        ds, has_raw_data, has_attributes = result
+        return ds.to_domain(has_raw_data, has_attributes)
+
+    async def get_by_name(self, name: str) -> Dataset | None:
+        workspace_id = self._ensure_workspace_id()
+        return await self.get_one_with_has_data(
+            (db.Dataset.workspace_id == workspace_id) & (db.Dataset.name == name)
+        )
+
+    async def get_by_id(self, id: UUID) -> Dataset | None:
+        return await self.get_one_with_has_data(db.Dataset.id == id)
+
+    async def delete(self, id: UUID):
+        await self.all_data.dataset_data.delete(id)
+        await self.session.execute(delete(db.Dataset).where(db.Dataset.id == id))
+
+    async def get_summary(self, id: UUID):
+        dataset = await self.get_by_id(id)
+        if dataset is None:
+            raise ResourceDoesNotExist("dataset", id=id)
+
+        entity_groups: dict[str, EntityGroupSummary] = {}
+        attribute: db.Attribute
+        for attribute, min_val, max_val in await self.session.execute(
+            select(db.Attribute, db.DataArray.min_val, db.DataArray.max_val)
+            .join(db.Attribute)
+            .join(db.DatasetAttribute)
+            .options(
+                joinedload(db.Attribute.attribute_type),
+                joinedload(db.Attribute.entity_type),
+            )
+            .where(db.DatasetAttribute.dataset_id == id)
+        ):
+            attribute_type = attribute.attribute_type
+            entity_group_name = attribute.entity_type.name
+            entity_group = entity_groups.setdefault(
+                entity_group_name, EntityGroupSummary(entity_group_name, 0, [])
+            )
+
+            if attribute.attribute_type.name == "id":
+                entity_group.count = max(entity_group.count, attribute.length)
+            entity_group.attributes.append(
+                AttributeSummary(
+                    name=attribute_type.name,
+                    data_type=attribute_type.data_type,
+                    description=attribute_type.description,
+                    unit=attribute_type.unit,
+                    enum_name=attribute_type.enum_name,
+                    min_val=min_val,
+                    max_val=max_val,
+                )
+            )
+
+        return DatasetSummary(
+            general=dataset.general or {},
+            epsg_code=dataset.epsg_code,
+            bounding_box=dataset.bounding_box,
+            entity_groups=sorted(
+                (
+                    dataclasses.replace(eg, attributes=sorted(eg.attributes, key=lambda a: a.name))
+                    for eg in entity_groups.values()
+                ),
+                key=lambda eg: eg.name,
+            ),
+            count=sum(e.count for e in entity_groups.values()),
+        )
+
+    @map_errors(
+        {
+            sqlalchemy.exc.IntegrityError: lambda obj: ResourceAlreadyExists(
+                "dataset", name=obj.name
+            )
+        }
+    )
+    async def create(self, obj: Dataset) -> UUID:
+        workspace_id = self._ensure_workspace_id()
+        dataset_type = await self.all_data.dataset_types.ensure_dataset_type(obj.dataset_type)
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.Dataset)
+                .values(
+                    workspace_id=workspace_id,
+                    name=obj.name,
+                    display_name=obj.display_name,
+                    dataset_type_id=t.cast(UUID, dataset_type.id),
+                )
+                .returning(db.Dataset.id)
+            ),
+        )
+
+    async def update(self, id: UUID, obj: Dataset):
+        current = await self.get_by_id(id)
+        if current is None:
+            raise ResourceDoesNotExist("dataset", id=id)
+        await self.session.execute(
+            update(db.Dataset)
+            .where(db.Dataset.id == id)
+            .values(name=obj.name, display_name=obj.display_name)
+        )
+
+    async def update_with_data(self, id: UUID, obj: Dataset, chunk_size=0):
+        current = await self.get_by_id(id)
+        if current is None:
+            raise ResourceDoesNotExist("dataset", id=id)
+        if obj.data is None:
+            raise InvalidAction("Must provide dataset data")
+        if not (
+            obj.dataset_type.format == DatasetFormat.UNKNOWN
+            or obj.dataset_type == current.dataset_type
+        ):
+            raise InvalidAction("Cannot change dataset type when updating data")
+        await self.all_data.dataset_data.delete(id)
+        await self.session.execute(
+            update(db.Dataset)
+            .where(db.Dataset.id == id)
+            .values(
+                name=obj.name,
+                display_name=obj.display_name,
+                general=obj.general,
+                epsg_code=obj.epsg_code,
+                bounding_box=obj.bounding_box.as_tuple_or_none(),
+            )
+        )
+        await self.all_data.dataset_data.create(
+            id, data=obj.data, format=current.dataset_type.format, chunk_size=chunk_size
+        )
+
+    async def ensure_scenario_datasets(
+        self, datasets: t.Sequence[ScenarioDataset]
+    ) -> t.List[ScenarioDataset]:
+        workspace_id = self._ensure_workspace_id()
+        existing_datasets = {
+            ds.name: t.cast(db.Dataset, ds)
+            for ds in await self.session.scalars(
+                self.selector.where(
+                    db.Dataset.name.in_(ds.name for ds in datasets),
+                )
+            )
+        }
+        to_create = []
+        for scenario_dataset in datasets:
+            name = scenario_dataset.name
+            if name not in existing_datasets:
+                if self.options.STRICT_SCENARIO_DATASETS:
+                    raise ResourceDoesNotExist("dataset", name=name)
+                to_create.append(scenario_dataset)
+                continue
+            if scenario_dataset.type != existing_datasets[name].dataset_type.name:
+                raise InvalidResource(
+                    "dataset",
+                    name=name,
+                    message="incompatible dataset already exists",
+                )
+        if to_create:
+            existing_types = {tp.name: tp for tp in await self.all_data.dataset_types.list()}
+            for scenario_dataset in to_create:
+                if scenario_dataset.type not in existing_types:
+                    new_type = await self.all_data.dataset_types.ensure_dataset_type(
+                        DatasetType(scenario_dataset.type, format=DatasetFormat.ENTITY_BASED)
+                    )
+                    existing_types[new_type.name] = new_type
+
+            created = await self.session.scalars(
+                insert(db.Dataset).returning(db.Dataset),
+                [
+                    {
+                        "name": ds.name,
+                        "display_name": ds.name,
+                        "dataset_type_id": existing_types[ds.type].id,
+                        "workspace_id": workspace_id,
+                    }
+                    for ds in to_create
+                ],
+            )
+
+            existing_datasets.update((ds.name, ds) for ds in created)
+
+        return [
+            ScenarioDataset(name=ds.name, type=ds.type, id=existing_datasets[ds.name].id)
+            for ds in datasets
+        ]
+
+
+class DatasetDataRepository(SQLResourceRepository):
+    async def exists_for(self, id: UUID):
+        raw_data_exists = await self._exists(db.RawData.dataset_id == id)
+        entity_data_exists = await self._exists(db.DatasetAttribute.dataset_id == id)
+        return raw_data_exists or entity_data_exists
+
+    def stream_binary_data(
+        self, id: UUID, yield_per=1
+    ) -> t.Coroutine[None, None, tuple[str | None, t.AsyncGenerator[bytes]]]:
+        return RawDataProcessor(self.session).stream_bytes(id, yield_per=yield_per)
+
+    def get_unstructured_data(self, id: UUID):
+        return RawDataProcessor(self.session).get_dict(id)
+
+    def get_entity_data(self, id: UUID):
+        return EntityDataProcessor(
+            self.session, all_data=self.all_data, selector=DatasetDataSelector()
+        ).get(id)
+
+    async def create(self, id: UUID, data: DatasetData, format: DatasetFormat, chunk_size=0):
+        """Store dataset data for a dataset. The dataset must currently not contain any data
+
+        :param id: A dataset id
+        :param data: The dataset data as dict, bytes, BytesIO or pathlib.Path
+        :param format: The dataset's ``DatasetFormat``
+        :param chunk_size: The maximum chunk size in bytes to store data. By default set to the
+            value of DatasetRepository.RAW_DATA_CHUNK_SIZE. This parameter is ignore when the
+            dataset format is DatasetFormat.ENTITY_BASED
+        """
+
+        if await self.exists_for(id):
+            raise InvalidResource("dataset", id=id, message="Dataset already has data")
+
+        if format == DatasetFormat.ENTITY_BASED:
+            if not isinstance(data, dict):
+                raise ValueError("Entity based data must be provided as a dictionary")
+            await EntityDataProcessor(
+                self.session, self.all_data, selector=DatasetDataSelector()
+            ).store(id, data)
+
+        if format == DatasetFormat.UNSTRUCTURED:
+            await RawDataProcessor(self.session).store(id, data, chunk_size=chunk_size)
+
+        if format == DatasetFormat.BINARY:
+            await RawDataProcessor(self.session).store(id, data, chunk_size=chunk_size)
+
+    async def delete(self, id: UUID):
+        await self.session.execute(
+            delete(db.Attribute).where(
+                db.Attribute.id.in_(
+                    select(db.DatasetAttribute.attribute_id).where(
+                        db.DatasetAttribute.dataset_id == id
+                    )
+                )
+            )
+        )
+        await self.session.execute(delete(db.RawData).where(db.RawData.dataset_id == id))
+        await self.session.execute(
+            update(db.Dataset)
+            .where(db.Dataset.id == id)
+            .values(general=None, epsg_code=None, bounding_box=None)
+        )
+
+
+class DatasetDataSelector(EntityDataSelector):
+    def select_linked_attribute(self, id: UUID) -> Select[tuple[db.Attribute]]:
+        return (
+            select(db.Attribute)
+            .join(db.DatasetAttribute)
+            .where(db.DatasetAttribute.dataset_id == id)
+        )
+
+    def insert_linked_attribute(self, id: UUID, attribute_id: UUID) -> Insert:
+        return insert(db.DatasetAttribute).values(dataset_id=id, attribute_id=attribute_id)

--- a/packages/data-core/src/movici_data_core/database/repository/general.py
+++ b/packages/data-core/src/movici_data_core/database/repository/general.py
@@ -158,7 +158,7 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
     async def ensure_attribute_type(self, attribute_type: AttributeType) -> AttributeType:
         existing = await self.get_by_name(attribute_type.name)
         if not existing:
-            if self.options.STRICT_ATTRIBUTES:
+            if self.options.STRICT_ATTRIBUTE_TYPES:
                 raise ResourceDoesNotExist("attribute_type", name=attribute_type.name)
             attribute_type_id = await self.create(attribute_type)
             existing = t.cast(AttributeType, await self.get_by_id(attribute_type_id))

--- a/packages/data-core/src/movici_data_core/database/repository/general.py
+++ b/packages/data-core/src/movici_data_core/database/repository/general.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+import typing as t
+from uuid import UUID
+
+from sqlalchemy import insert, select, update
+
+from movici_data_core.database import model as db
+from movici_data_core.domain_model import (
+    AttributeDataType,
+    AttributeType,
+    DatasetFormat,
+    DatasetType,
+    EntityType,
+    ModelType,
+)
+from movici_data_core.exceptions import (
+    InvalidAction,
+    InvalidResource,
+    ResourceDoesNotExist,
+)
+
+from .common import GenericResourceRepository, ensure_valid_id
+
+
+class DatasetTypeRepository(GenericResourceRepository[DatasetType]):
+    __resource__ = db.DatasetType
+    __resource_type_name__ = "dataset_type"
+
+    # TODO: prevent creating dataset type with UNKNOWN format
+    async def create(self, obj: DatasetType) -> UUID:
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.DatasetType)
+                .values(name=obj.name, format=obj.format, mimetype=obj.mimetype)
+                .returning(db.DatasetType.id)
+            ),
+        )
+
+    # TODO: prevent updating dataset type with UNKNOWN format
+    async def update(self, id: UUID, obj: DatasetType):
+        current = await self.get_by_id(id)
+        if current is None:
+            raise ResourceDoesNotExist("dataset_type", id=id)
+        if current.format != obj.format:
+            raise InvalidAction("Cannot update dataset type format")
+
+        mimetype = obj.mimetype if obj.format == DatasetFormat.BINARY else None
+
+        await self.session.execute(
+            update(db.DatasetType)
+            .where(db.DatasetType.id == id)
+            .values(name=obj.name, mimetype=mimetype)
+        )
+
+    async def ensure_dataset_type(self, dataset_type: DatasetType) -> DatasetType:
+        existing = await self.get_by_name(dataset_type.name)
+        if not existing:
+            if self.options.STRICT_DATASET_TYPES:
+                raise ResourceDoesNotExist("dataset_type", name=dataset_type.name)
+            dataset_type_id = await self.create(dataset_type)
+            existing = await self.get_by_id(dataset_type_id)
+
+        if dataset_type.format != DatasetFormat.UNKNOWN and existing != dataset_type:
+            raise InvalidResource(
+                "dataset_type",
+                name=dataset_type.name,
+                message="incompatible dataset_type already exists",
+            )
+        return t.cast(DatasetType, existing)
+
+
+class EntityTypeRepository(GenericResourceRepository[EntityType]):
+    __resource__ = db.EntityType
+    __resource_type_name__ = "entity_type"
+
+    async def create(self, obj: EntityType) -> UUID:
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.EntityType).values(name=obj.name).returning(db.EntityType.id)
+            ),
+        )
+
+    @ensure_valid_id
+    async def update(self, id: UUID, obj: EntityType):
+        await self.session.execute(
+            update(db.EntityType).where(db.EntityType.id == id).values(name=obj.name)
+        )
+
+    async def ensure_entity_type(self, entity_type: EntityType) -> EntityType:
+        existing = await self.get_by_name(entity_type.name)
+        if not existing:
+            if self.options.STRICT_ENTITY_TYPES:
+                raise ResourceDoesNotExist("entity_type", name=entity_type.name)
+
+            entity_type_id = await self.create(entity_type)
+            existing = await self.get_by_id(entity_type_id)
+
+        return t.cast(EntityType, existing)
+
+
+class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
+    __resource__ = db.AttributeType
+    __resource_type_name__ = "attribute_type"
+
+    async def create(self, obj: AttributeType) -> UUID:
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.AttributeType)
+                .values(
+                    name=obj.name,
+                    has_rowptr=obj.data_type.csr,
+                    unit_type=self.db_unit_type(obj.data_type.py_type),
+                    unit_shape=obj.data_type.unit_shape,
+                    unit=obj.unit,
+                    description=obj.description,
+                    enum_name=obj.enum_name,
+                )
+                .returning(db.AttributeType.id)
+            ),
+        )
+
+    def db_unit_type(self, py_type: AttributeDataType):
+        return {
+            bool: db.AttributeDataType.BOOL,
+            int: db.AttributeDataType.INT,
+            float: db.AttributeDataType.FLOAT,
+            str: db.AttributeDataType.STR,
+        }[py_type]
+
+    async def update(self, id: UUID, obj: AttributeType):
+        current = await self.get_by_id(id)
+        if current is None:
+            raise ResourceDoesNotExist("attribute_type", id=id)
+        in_use = await self.session.scalar(
+            select(db.Attribute.id).where(db.Attribute.attribute_type_id == id).limit(1)
+        )
+
+        if in_use and not current.data_type == obj.data_type:
+            raise InvalidAction("cannot change attribute data type when it is in use")
+
+        await self.session.execute(
+            update(db.AttributeType)
+            .where(db.AttributeType.id == id)
+            .values(
+                name=obj.name,
+                has_rowptr=obj.data_type.csr,
+                unit_type=self.db_unit_type(obj.data_type.py_type),
+                unit_shape=obj.data_type.unit_shape,
+                unit=obj.unit,
+                description=obj.description,
+            )
+        )
+
+    async def ensure_attribute_type(self, attribute_type: AttributeType) -> AttributeType:
+        existing = await self.get_by_name(attribute_type.name)
+        if not existing:
+            if self.options.STRICT_ATTRIBUTES:
+                raise ResourceDoesNotExist("attribute_type", name=attribute_type.name)
+            attribute_type_id = await self.create(attribute_type)
+            existing = t.cast(AttributeType, await self.get_by_id(attribute_type_id))
+
+        if not existing.data_type == attribute_type.data_type:
+            raise InvalidResource(
+                "attribute_type",
+                name=attribute_type.name,
+                message="incompatible attribute_type already exists",
+            )
+        return existing
+
+
+class ModelTypeRepository(GenericResourceRepository[ModelType]):
+    __resource__ = db.ModelType
+    __resource_type_name__ = "model_type"
+
+    async def create(self, obj: ModelType) -> UUID:
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.ModelType)
+                .values(name=obj.name, jsonschema=obj.jsonschema)
+                .returning(db.ModelType.id)
+            ),
+        )
+
+    @ensure_valid_id
+    async def update(self, id: UUID, obj: ModelType):
+        await self.session.execute(
+            update(db.ModelType)
+            .where(db.ModelType.id == id)
+            .values(name=obj.name, jsonschema=obj.jsonschema)
+        )
+
+    async def ensure_model_types(self, model_types: t.Sequence[str]) -> list[ModelType]:
+        existing_model_types = {
+            tp.name: t.cast(db.ModelType, tp)
+            for tp in await self.session.scalars(
+                select(db.ModelType).where(
+                    db.ModelType.name.in_(model_types),
+                )
+            )
+        }
+        to_create = []
+        for model_type in model_types:
+            if model_type not in existing_model_types:
+                if self.options.STRICT_MODEL_TYPES:
+                    raise ResourceDoesNotExist("model_type", name=model_type)
+                to_create.append(model_type)
+                continue
+
+        if to_create:
+            created = await self.session.scalars(
+                insert(db.ModelType).returning(db.ModelType),
+                [{"name": tp, "jsonschema": self.default_jsonschema(tp)} for tp in to_create],
+            )
+
+            existing_model_types.update((tp.name, tp) for tp in created)
+
+        return [existing_model_types[tp].to_domain() for tp in model_types]
+
+    @staticmethod
+    def default_jsonschema(name: str):
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": f"/{name}/1.0.0",
+            "type": "object",
+            "additionalProperties": True,
+        }

--- a/packages/data-core/src/movici_data_core/database/repository/general.py
+++ b/packages/data-core/src/movici_data_core/database/repository/general.py
@@ -29,6 +29,11 @@ class DatasetTypeRepository(GenericResourceRepository[DatasetType]):
 
     # TODO: prevent creating dataset type with UNKNOWN format
     async def create(self, obj: DatasetType) -> UUID:
+        """Store a :class:``DatasetType`` in the database
+
+        :param obj: the ``DatasetType`` object
+        :return: the UUID of the stored ``DatasetType``
+        """
         return t.cast(
             UUID,
             await self.session.scalar(
@@ -40,6 +45,13 @@ class DatasetTypeRepository(GenericResourceRepository[DatasetType]):
 
     # TODO: prevent updating dataset type with UNKNOWN format
     async def update(self, id: UUID, obj: DatasetType):
+        """Update a :class:``DatasetType`` in the database
+
+        Valid fields to update are: ``name``, ``mimetype``
+
+        :param id: the UUID of the stored ``DatasetType``
+        :param obj: the ``DatasetType`` object
+        """
         current = await self.get_by_id(id)
         if current is None:
             raise ResourceDoesNotExist("dataset_type", id=id)
@@ -55,6 +67,15 @@ class DatasetTypeRepository(GenericResourceRepository[DatasetType]):
         )
 
     async def ensure_dataset_type(self, dataset_type: DatasetType) -> DatasetType:
+        """Ensure that a dataset type exists in the database or raise an error. If the dataset type
+        does not exist and the database option ``STRICT_DATASET_TYPES`` is unset, the dataset
+        type will be created. If the ``STRICT_DATASET_TYPES`` options is set, an error is raised
+        instead. An error will also be raised if an attempt is made to create a DatasetType with
+        the ``DatasetType.UNKNOWN`` format.
+
+        :param dataset_type: the ``DatasetType`` object to ensure.
+        :return: the ``DatasetType`` object as it exists in the database
+        """
         existing = await self.get_by_name(dataset_type.name)
         if not existing:
             if self.options.STRICT_DATASET_TYPES:
@@ -76,6 +97,11 @@ class EntityTypeRepository(GenericResourceRepository[EntityType]):
     __resource_type_name__ = "entity_type"
 
     async def create(self, obj: EntityType) -> UUID:
+        """Store a :class:``EntityType`` in the database
+
+        :param obj: the ``EntityType`` object
+        :return: the UUID of the stored ``EntityType``
+        """
         return t.cast(
             UUID,
             await self.session.scalar(
@@ -85,6 +111,13 @@ class EntityTypeRepository(GenericResourceRepository[EntityType]):
 
     @ensure_valid_id
     async def update(self, id: UUID, obj: EntityType):
+        """Update a :class:``EntityType`` in the database
+
+        Valid fields to update are: ``name``
+
+        :param id: the UUID of the stored ``EntityType``
+        :param obj: the ``EntityType`` object with the changes
+        """
         await self.session.execute(
             update(db.EntityType).where(db.EntityType.id == id).values(name=obj.name)
         )
@@ -106,6 +139,11 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
     __resource_type_name__ = "attribute_type"
 
     async def create(self, obj: AttributeType) -> UUID:
+        """Store a :class:``AttributeType`` in the database
+
+        :param obj: the ``AttributeType`` object
+        :return: the UUID of the stored ``AttributeType``
+        """
         return t.cast(
             UUID,
             await self.session.scalar(
@@ -113,7 +151,7 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
                 .values(
                     name=obj.name,
                     has_rowptr=obj.data_type.csr,
-                    unit_type=self.db_unit_type(obj.data_type.py_type),
+                    unit_type=self._db_unit_type(obj.data_type.py_type),
                     unit_shape=obj.data_type.unit_shape,
                     unit=obj.unit,
                     description=obj.description,
@@ -123,7 +161,7 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
             ),
         )
 
-    def db_unit_type(self, py_type: AttributeDataType):
+    def _db_unit_type(self, py_type: AttributeDataType):
         return {
             bool: db.AttributeDataType.BOOL,
             int: db.AttributeDataType.INT,
@@ -132,6 +170,14 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
         }[py_type]
 
     async def update(self, id: UUID, obj: AttributeType):
+        """Update a :class:``AttributeType`` in the database
+
+        Valid fields to update are: ``name``, ``data_type``, ``unit``, ``description``,
+        ``enum_name``
+
+        :param id: the UUID of the stored ``EntityType``
+        :param obj: the ``EntityType`` object with the changes
+        """
         current = await self.get_by_id(id)
         if current is None:
             raise ResourceDoesNotExist("attribute_type", id=id)
@@ -148,14 +194,24 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
             .values(
                 name=obj.name,
                 has_rowptr=obj.data_type.csr,
-                unit_type=self.db_unit_type(obj.data_type.py_type),
+                unit_type=self._db_unit_type(obj.data_type.py_type),
                 unit_shape=obj.data_type.unit_shape,
                 unit=obj.unit,
                 description=obj.description,
+                enum_name=obj.enum_name,
             )
         )
 
     async def ensure_attribute_type(self, attribute_type: AttributeType) -> AttributeType:
+        """Ensure that an attribute type exists in the database or raise an error. If the attribute
+        type does not exist and the database option ``STRICT_ATTRIBUTE_TYPES`` is unset, the
+        attribute type will be created. If the ``STRICT_ATTRIBUTE_TYPES`` options is set, an error
+        is raised instead. An error will also be raised if an ``AttributeType`` with a different
+        data_type already exists.
+
+        :param attribute_type: the ``AttributeType`` object to ensure.
+        :return: the ``AttributeType`` object as it exists in the database
+        """
         existing = await self.get_by_name(attribute_type.name)
         if not existing:
             if self.options.STRICT_ATTRIBUTE_TYPES:
@@ -163,7 +219,7 @@ class AttributeTypeRepository(GenericResourceRepository[AttributeType]):
             attribute_type_id = await self.create(attribute_type)
             existing = t.cast(AttributeType, await self.get_by_id(attribute_type_id))
 
-        if not existing.data_type == attribute_type.data_type:
+        if existing.data_type != attribute_type.data_type:
             raise InvalidResource(
                 "attribute_type",
                 name=attribute_type.name,
@@ -177,6 +233,11 @@ class ModelTypeRepository(GenericResourceRepository[ModelType]):
     __resource_type_name__ = "model_type"
 
     async def create(self, obj: ModelType) -> UUID:
+        """Store a :class:``ModelType`` in the database
+
+        :param obj: the ``ModelType`` object
+        :return: the UUID of the stored ``ModelType``
+        """
         return t.cast(
             UUID,
             await self.session.scalar(
@@ -188,6 +249,13 @@ class ModelTypeRepository(GenericResourceRepository[ModelType]):
 
     @ensure_valid_id
     async def update(self, id: UUID, obj: ModelType):
+        """Update a :class:``ModelType`` in the database
+
+        Valid fields to update are: ``name``, ``jsonschema``
+
+        :param id: the UUID of the stored ``ModelType``
+        :param obj: the ``ModelType`` object with the changes
+        """
         await self.session.execute(
             update(db.ModelType)
             .where(db.ModelType.id == id)
@@ -195,6 +263,14 @@ class ModelTypeRepository(GenericResourceRepository[ModelType]):
         )
 
     async def ensure_model_types(self, model_types: t.Sequence[str]) -> list[ModelType]:
+        """Ensure that a sequence of model types exist in the database or raise an error. If one or
+        more of the model types does not exist and the database option ``STRICT_MODEL_TYPES`` is
+        unset, the non-existing model types will be created. If the ``STRICT_MODEL_TYPES`` options
+        is set, an error is raised instead.
+        :param model_types: The model types to ensure, as a sequence of model type names
+        :return: the ``ModelType`` objects as they exist in the database, in the same order as the
+            input sequence
+        """
         existing_model_types = {
             tp.name: t.cast(db.ModelType, tp)
             for tp in await self.session.scalars(
@@ -214,7 +290,7 @@ class ModelTypeRepository(GenericResourceRepository[ModelType]):
         if to_create:
             created = await self.session.scalars(
                 insert(db.ModelType).returning(db.ModelType),
-                [{"name": tp, "jsonschema": self.default_jsonschema(tp)} for tp in to_create],
+                [{"name": tp, "jsonschema": self._default_jsonschema(tp)} for tp in to_create],
             )
 
             existing_model_types.update((tp.name, tp) for tp in created)
@@ -222,7 +298,7 @@ class ModelTypeRepository(GenericResourceRepository[ModelType]):
         return [existing_model_types[tp].to_domain() for tp in model_types]
 
     @staticmethod
-    def default_jsonschema(name: str):
+    def _default_jsonschema(name: str):
         return {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "$id": f"/{name}/1.0.0",

--- a/packages/data-core/src/movici_data_core/database/repository/scenario.py
+++ b/packages/data-core/src/movici_data_core/database/repository/scenario.py
@@ -202,7 +202,7 @@ class ScenarioRepository(SQLResourceRepository):
         ):
             refs_to_add.extend(
                 validator.iter_scenario_model_references(
-                    dataclasses.replace(scenario_model, id=record.id)
+                    id=record.id, scenario_model=scenario_model
                 )
             )
 

--- a/packages/data-core/src/movici_data_core/database/repository/scenario.py
+++ b/packages/data-core/src/movici_data_core/database/repository/scenario.py
@@ -21,12 +21,17 @@ from movici_simulation_core.validate import MoviciDataRefInfo
 from .common import SQLResourceRepository
 
 
+# TODO: implement a `get_bounding_box` function that looks up the bounding boxes for all scnenario
+# datasets and updates and combines it into one. Question: what if the datasets have different CRS?
 @dataclasses.dataclass
 class ScenarioRepository(SQLResourceRepository):
+    """A"""
+
     workspace_id: UUID | None = None
     scenario_id: UUID | None = None
 
     def for_id(self, scenario_id: UUID):
+        """Bind the ScenarioRepository to a specific scenario"""
         self._ensure_no_scenario_id()
         return dataclasses.replace(self, scenario_id=scenario_id)
 
@@ -45,6 +50,7 @@ class ScenarioRepository(SQLResourceRepository):
             raise InvalidAction("Unsupported operation for this mode")
 
     async def list(self) -> list[Scenario]:
+        """List all scenarios in the active workspace"""
         workspace_id = self._ensure_workspace_id()
         result = await self.session.scalars(
             select(db.Scenario)
@@ -71,36 +77,50 @@ class ScenarioRepository(SQLResourceRepository):
         )
 
     async def exists_by_name(self, name: str):
+        """checks whether a scenario with a specific name exists in the active workspace
+        :return: bool
+        """
         workspace_id = self._ensure_workspace_id()
         return await self._exists(
             db.Scenario.workspace_id == workspace_id, db.Scenario.name == name
         )
 
-    async def exists(self):
-        id = self._ensure_scenario_id()
-        return await self._exists(db.Scenario.id == id)
-
     async def get_by_name(self, name: str) -> Scenario | None:
+        """Get a scenario by name, in the active workspace"""
         workspace_id = self._ensure_workspace_id()
         record = await self.session.scalar(
             self.selector.where(db.Scenario.name == name, db.Scenario.workspace_id == workspace_id)
         )
         if record is None:
             return None
-        return self.load_full_scenario(record)
+        return self._load_full_scenario(record)
 
-    async def get_by_id(self) -> Scenario | None:
+    async def get(self) -> Scenario | None:
+        """Get the active scenario from the database
+
+        :return: The Scenario, or None if it does not exist
+        """
         id = self._ensure_scenario_id()
         record = await self.session.scalar(self.selector.where(db.Scenario.id == id))
         if record is None:
             return None
-        return self.load_full_scenario(record)
+        return self._load_full_scenario(record)
 
     async def delete(self):
+        """Delete de active scenario, if it exists"""
         id = self._ensure_scenario_id()
         await self.session.execute(delete(db.Scenario).where(db.Scenario.id == id))
 
     async def create(self, obj: Scenario, validator: ModelConfigValidator) -> UUID:
+        """Store a new Scenario in the database. This method can only be invoked if there is no
+        currently active Scenario, to prevent creating scenarios when in a ``SINGLE_SCENARIO`` mode
+
+        :param obj: The scenario to create
+        :param validator: A ModelConfigValidator that is instantiated with all available models in
+            the dataset
+        :return: the newly created Scenario UUID
+        """
+
         self._ensure_no_scenario_id()
         workspace_id = self._ensure_workspace_id()
         scenario_id = await self.session.scalar(
@@ -121,8 +141,14 @@ class ScenarioRepository(SQLResourceRepository):
         return scenario_id
 
     async def update(self, obj: Scenario, validator: ModelConfigValidator):
+        """Update a scenario in the database. The scenario to update must be the active scenario
+
+        :param obj: The sc
+        :param validator: A ModelConfigValidator that is instantiated with all available models in
+            the dataset
+        """
         id = self._ensure_scenario_id()
-        current = await self.get_by_id()
+        current = await self.get()
         if current is None:
             raise ResourceDoesNotExist("scenario", id=id)
         assert current.workspace is not None
@@ -148,7 +174,10 @@ class ScenarioRepository(SQLResourceRepository):
 
         await self._store_scenario_details(current.workspace.id, id, obj, validator)
 
+    # TODO: test this, and perhaps rethink how to deal with scenariostatus (see TODO for
+    # ScenarioStatus)
     async def set_status(self, status: ScenarioStatus):
+        """Set the ScenarioStatus for the active scenario"""
         id = self._ensure_scenario_id()
         await self.session.execute(
             update(db.Scenario).where(db.Scenario.id == id).values(status=status)
@@ -191,7 +220,7 @@ class ScenarioRepository(SQLResourceRepository):
                     "scenario_id": scenario_id,
                     "model_type_id": model_type.id,
                     "sequence": idx,
-                    "config": self.stripped_config(model),
+                    "config": self._stripped_config(model),
                 }
                 for idx, (model, model_type) in enumerate(zip(scenario_models, model_types))
             ],
@@ -210,7 +239,7 @@ class ScenarioRepository(SQLResourceRepository):
             await self.session.execute(insert(db.ScenarioModelReference), refs_to_add)
 
     @classmethod
-    def load_full_scenario(cls, scenario: db.Scenario) -> Scenario:
+    def _load_full_scenario(cls, scenario: db.Scenario) -> Scenario:
         return dataclasses.replace(
             scenario.to_domain(),
             datasets=[
@@ -249,7 +278,7 @@ class ScenarioRepository(SQLResourceRepository):
         return result
 
     @staticmethod
-    def stripped_config(scenario_model: ScenarioModel):
+    def _stripped_config(scenario_model: ScenarioModel):
         result = copy.deepcopy(scenario_model.config)
         result.pop("name", None)
         result.pop("type", None)

--- a/packages/data-core/src/movici_data_core/database/repository/scenario.py
+++ b/packages/data-core/src/movici_data_core/database/repository/scenario.py
@@ -14,7 +14,7 @@ from movici_data_core.domain_model import (
     ScenarioModel,
     ScenarioStatus,
 )
-from movici_data_core.exceptions import InvalidAction, ResourceDoesNotExist
+from movici_data_core.exceptions import InvalidAction, MoviciValidationError, ResourceDoesNotExist
 from movici_data_core.validators import ModelConfigValidator
 from movici_simulation_core.validate import MoviciDataRefInfo
 
@@ -207,11 +207,21 @@ class ScenarioRepository(SQLResourceRepository):
             return
 
         model_types = await self.all_data.model_types.ensure_model_types(
-            [model["type"] for model in obj.models if "name" in model]
+            [model["type"] for model in obj.models if "type" in model]
         )
 
         validator = validator.for_scenario(scenario_datasets, model_types)
-        scenario_models = validator.process_model_configs(obj.models)
+        try:
+            scenario_models = validator.process_model_configs(obj.models)
+        except MoviciValidationError as e:
+            raise MoviciValidationError.from_errors(e, path="models") from e
+
+        # In the previous step where we create the model_type list, there is the possibility of
+        # a model config that does not specify a type, and we potentially end up with a list of
+        # model_types that is shorter that the number of scenario_models. However, validation must
+        # have caught this and raise an error if a model does not have a "type" field. So we
+        # can assert that we always have the correct length of lists here
+        assert len(scenario_models) == len(model_types)
         scenario_model_records = await self.session.scalars(
             insert(db.ScenarioModel).returning(db.ScenarioModel),
             [

--- a/packages/data-core/src/movici_data_core/database/repository/scenario.py
+++ b/packages/data-core/src/movici_data_core/database/repository/scenario.py
@@ -111,7 +111,7 @@ class ScenarioRepository(SQLResourceRepository):
                 display_name=obj.display_name,
                 description=obj.description,
                 status=obj.status,
-                simulation_info=obj.simulation_info,
+                simulation_info=dataclasses.asdict(obj.simulation_info),
                 epsg_code=obj.epsg_code,
             )
             .returning(db.Scenario.id)
@@ -135,7 +135,7 @@ class ScenarioRepository(SQLResourceRepository):
                 name=obj.name,
                 display_name=obj.display_name,
                 description=obj.description,
-                simulation_info=obj.simulation_info,
+                simulation_info=dataclasses.asdict(obj.simulation_info),
                 epsg_code=obj.epsg_code,
             )
         )

--- a/packages/data-core/src/movici_data_core/database/repository/scenario.py
+++ b/packages/data-core/src/movici_data_core/database/repository/scenario.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import copy
+import dataclasses
+from uuid import UUID
+
+from sqlalchemy import delete, insert, select, update
+from sqlalchemy.orm import joinedload, selectinload
+
+from movici_data_core.database import model as db
+from movici_data_core.domain_model import (
+    Scenario,
+    ScenarioDataset,
+    ScenarioModel,
+    ScenarioStatus,
+)
+from movici_data_core.exceptions import InvalidAction, ResourceDoesNotExist
+from movici_data_core.validators import ModelConfigValidator
+from movici_simulation_core.validate import MoviciDataRefInfo
+
+from .common import SQLResourceRepository
+
+
+@dataclasses.dataclass
+class ScenarioRepository(SQLResourceRepository):
+    workspace_id: UUID | None = None
+    scenario_id: UUID | None = None
+
+    def for_id(self, scenario_id: UUID):
+        self._ensure_no_scenario_id()
+        return dataclasses.replace(self, scenario_id=scenario_id)
+
+    def _ensure_workspace_id(self) -> UUID:
+        if self.workspace_id is None:
+            raise ValueError("ScenarioRepository.workspace_id is required")
+        return self.workspace_id
+
+    def _ensure_scenario_id(self):
+        if self.scenario_id is None:
+            raise ValueError("ScenarioRepository.scenario_id is required")
+        return self.scenario_id
+
+    def _ensure_no_scenario_id(self):
+        if self.scenario_id is not None:
+            raise InvalidAction("Unsupported operation for this mode")
+
+    async def list(self) -> list[Scenario]:
+        workspace_id = self._ensure_workspace_id()
+        result = await self.session.scalars(
+            select(db.Scenario)
+            .options(joinedload(db.Scenario.workspace))
+            .where(db.Scenario.workspace_id == workspace_id)
+        )
+        return [obj.to_domain() for obj in result]
+
+    @property
+    def selector(self):
+        return select(db.Scenario).options(
+            joinedload(db.Scenario.workspace),
+            selectinload(db.Scenario.datasets)
+            .joinedload(db.ScenarioDataset.dataset)
+            .joinedload(db.Dataset.dataset_type),
+            selectinload(db.Scenario.models).options(
+                joinedload(db.ScenarioModel.model_type),
+                selectinload(db.ScenarioModel.references).options(
+                    joinedload(db.ScenarioModelReference.dataset),
+                    joinedload(db.ScenarioModelReference.entity_type),
+                    joinedload(db.ScenarioModelReference.attribute_type),
+                ),
+            ),
+        )
+
+    async def exists_by_name(self, name: str):
+        workspace_id = self._ensure_workspace_id()
+        return await self._exists(
+            db.Scenario.workspace_id == workspace_id, db.Scenario.name == name
+        )
+
+    async def exists(self):
+        id = self._ensure_scenario_id()
+        return await self._exists(db.Scenario.id == id)
+
+    async def get_by_name(self, name: str) -> Scenario | None:
+        workspace_id = self._ensure_workspace_id()
+        record = await self.session.scalar(
+            self.selector.where(db.Scenario.name == name, db.Scenario.workspace_id == workspace_id)
+        )
+        if record is None:
+            return None
+        return self.load_full_scenario(record)
+
+    async def get_by_id(self) -> Scenario | None:
+        id = self._ensure_scenario_id()
+        record = await self.session.scalar(self.selector.where(db.Scenario.id == id))
+        if record is None:
+            return None
+        return self.load_full_scenario(record)
+
+    async def delete(self):
+        id = self._ensure_scenario_id()
+        await self.session.execute(delete(db.Scenario).where(db.Scenario.id == id))
+
+    async def create(self, obj: Scenario, validator: ModelConfigValidator) -> UUID:
+        self._ensure_no_scenario_id()
+        workspace_id = self._ensure_workspace_id()
+        scenario_id = await self.session.scalar(
+            insert(db.Scenario)
+            .values(
+                workspace_id=workspace_id,
+                name=obj.name,
+                display_name=obj.display_name,
+                description=obj.description,
+                status=obj.status,
+                simulation_info=obj.simulation_info,
+                epsg_code=obj.epsg_code,
+            )
+            .returning(db.Scenario.id)
+        )
+        assert scenario_id is not None
+        await self._store_scenario_details(workspace_id, scenario_id, obj, validator)
+        return scenario_id
+
+    async def update(self, obj: Scenario, validator: ModelConfigValidator):
+        id = self._ensure_scenario_id()
+        current = await self.get_by_id()
+        if current is None:
+            raise ResourceDoesNotExist("scenario", id=id)
+        assert current.workspace is not None
+        assert current.workspace.id is not None
+
+        await self.session.execute(
+            update(db.Scenario)
+            .where(db.Scenario.id == id)
+            .values(
+                name=obj.name,
+                display_name=obj.display_name,
+                description=obj.description,
+                simulation_info=obj.simulation_info,
+                epsg_code=obj.epsg_code,
+            )
+        )
+        await self.session.execute(
+            delete(db.ScenarioDataset).where(db.ScenarioDataset.scenario_id == id)
+        )
+        await self.session.execute(
+            delete(db.ScenarioModel).where(db.ScenarioModel.scenario_id == id)
+        )
+
+        await self._store_scenario_details(current.workspace.id, id, obj, validator)
+
+    async def set_status(self, status: ScenarioStatus):
+        id = self._ensure_scenario_id()
+        await self.session.execute(
+            update(db.Scenario).where(db.Scenario.id == id).values(status=status)
+        )
+
+    async def _store_scenario_details(
+        self,
+        workspace_id: UUID,
+        scenario_id: UUID,
+        obj: Scenario,
+        validator: ModelConfigValidator,
+    ):
+        repository = self.all_data.for_workspace(workspace_id)
+        scenario_datasets = []
+        if obj.datasets:
+            scenario_datasets = await repository.datasets.ensure_scenario_datasets(
+                [ScenarioDataset(ds["name"], ds["type"]) for ds in obj.datasets]
+            )
+            await self.session.execute(
+                insert(db.ScenarioDataset),
+                [
+                    {"scenario_id": scenario_id, "dataset_id": ds.id, "sequence": idx}
+                    for idx, ds in enumerate(scenario_datasets)
+                ],
+            )
+        if not obj.models:
+            return
+
+        model_types = await self.all_data.model_types.ensure_model_types(
+            [model["type"] for model in obj.models if "name" in model]
+        )
+
+        validator = validator.for_scenario(scenario_datasets, model_types)
+        scenario_models = validator.process_model_configs(obj.models)
+        scenario_model_records = await self.session.scalars(
+            insert(db.ScenarioModel).returning(db.ScenarioModel),
+            [
+                {
+                    "name": model.name,
+                    "scenario_id": scenario_id,
+                    "model_type_id": model_type.id,
+                    "sequence": idx,
+                    "config": self.stripped_config(model),
+                }
+                for idx, (model, model_type) in enumerate(zip(scenario_models, model_types))
+            ],
+        )
+        refs_to_add: list[dict] = []
+        for scenario_model, record in zip(
+            scenario_models, sorted(scenario_model_records, key=lambda r: r.sequence)
+        ):
+            refs_to_add.extend(
+                validator.iter_scenario_model_references(
+                    dataclasses.replace(scenario_model, id=record.id)
+                )
+            )
+
+        if refs_to_add:
+            await self.session.execute(insert(db.ScenarioModelReference), refs_to_add)
+
+    @classmethod
+    def load_full_scenario(cls, scenario: db.Scenario) -> Scenario:
+        return dataclasses.replace(
+            scenario.to_domain(),
+            datasets=[
+                cls._load_scenario_dataset(ds)
+                for ds in sorted(scenario.datasets, key=lambda ds: ds.sequence)
+            ],
+            models=[
+                cls._load_scenario_model(model)
+                for model in sorted(scenario.models, key=lambda model: model.sequence)
+            ],
+        )
+
+    @staticmethod
+    def _load_scenario_dataset(scenario_dataset: db.ScenarioDataset):
+        return {
+            "id": scenario_dataset.dataset_id,
+            "name": scenario_dataset.dataset.name,
+            "type": scenario_dataset.dataset.dataset_type.name,
+        }
+
+    @classmethod
+    def _load_scenario_model(cls, scenario_model: db.ScenarioModel):
+        result = copy.deepcopy(scenario_model.config)
+        for data_ref in scenario_model.references:
+            value = None
+            if data_ref.dataset is not None:
+                value = data_ref.dataset.name
+            elif data_ref.entity_type is not None:
+                value = data_ref.entity_type.name
+            elif data_ref.attribute_type is not None:
+                value = data_ref.attribute_type.name
+            MoviciDataRefInfo.from_path_string(data_ref.path, value).set_value(result)
+
+        result["name"] = scenario_model.name
+        result["type"] = scenario_model.model_type.name
+        return result
+
+    @staticmethod
+    def stripped_config(scenario_model: ScenarioModel):
+        result = copy.deepcopy(scenario_model.config)
+        result.pop("name", None)
+        result.pop("type", None)
+        for ref in scenario_model.references:
+            ref.unset_value(result)
+        return result

--- a/packages/data-core/src/movici_data_core/database/repository/updates.py
+++ b/packages/data-core/src/movici_data_core/database/repository/updates.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import dataclasses
+import typing as t
+from uuid import UUID
+
+from sqlalchemy import delete, insert, select
+from sqlalchemy.orm import joinedload
+
+from movici_data_core.database import model as db
+from movici_data_core.domain_model import Update
+from movici_data_core.exceptions import (
+    InvalidAction,
+    MoviciValidationError,
+    ResourceDoesNotExist,
+)
+
+from .common import EntityDataProcessor, EntityDataSelector, SQLResourceRepository
+
+
+@dataclasses.dataclass
+class UpdateRepository(SQLResourceRepository):
+    scenario_id: UUID
+
+    @property
+    def selector(self):
+        return select(db.Update).options(
+            joinedload(db.Update.dataset).joinedload(db.Dataset.dataset_type),
+            joinedload(db.Update.model_type),
+        )
+
+    async def list(self) -> list[Update]:
+        result = await self.session.scalars(
+            self.selector.where(db.Update.scenario_id == self.scenario_id).order_by(
+                db.Update.timestamp, db.Update.iteration
+            )
+        )
+        return [update.to_domain() for update in result]
+
+    async def exists(self):
+        return await self._exists(db.Update.scenario_id == self.scenario_id)
+
+    async def get_by_id(self, id: UUID, with_data=False) -> Update | None:
+        record = await self.session.scalar(self.selector.where(db.Update.id == id))
+        if record is None:
+            return None
+        result = record.to_domain()
+        if with_data:
+            result = dataclasses.replace(result, data=await self.get_data(id=id))
+        return result
+
+    async def get_data(self, id: UUID) -> dict:
+        return await EntityDataProcessor(
+            self.session, all_data=self.all_data, selector=UpdateDataSelector()
+        ).get(id)
+
+    async def create(self, obj: Update) -> UUID:
+        """
+        :param parent: A Scenario id
+        """
+        if not isinstance(obj.data, dict):
+            raise InvalidAction("update data must be a numpy dataset dict")
+        model_type_id = await self.session.scalar(
+            select(db.ModelType.id)
+            .join(db.ScenarioModel)
+            .where(db.ScenarioModel.scenario_id == self.scenario_id)
+            .where(db.ScenarioModel.name == obj.model_name)
+        )
+        if model_type_id is None:
+            raise MoviciValidationError(
+                f"{obj.model_name} is not a valid model for this scenario", "model_name"
+            )
+        dataset = await self.session.scalar(
+            select(db.Dataset)
+            .options(joinedload(db.Dataset.dataset_type))
+            .join(db.ScenarioDataset)
+            .where(db.ScenarioDataset.scenario_id == self.scenario_id)
+            .where(db.Dataset.name == obj.dataset.name)
+        )
+        if dataset is None:
+            raise ResourceDoesNotExist("dataset", name=obj.dataset.name)
+
+        update_id = t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.Update)
+                .values(
+                    scenario_id=self.scenario_id,
+                    timestamp=obj.timestamp,
+                    iteration=obj.iteration,
+                    model_type_id=model_type_id,
+                    model_name=obj.model_name,
+                    dataset_id=dataset.id,
+                )
+                .returning(db.Update.id)
+            ),
+        )
+        await EntityDataProcessor(self.session, self.all_data, UpdateDataSelector()).store(
+            update_id, obj.data
+        )
+        return update_id
+
+    async def delete_all(self):
+        await self.session.execute(
+            delete(db.Update).where(db.Update.scenario_id == self.scenario_id)
+        )
+
+
+class UpdateDataSelector(EntityDataSelector):
+    def select_linked_attribute(self, id: UUID):
+        return (
+            select(db.Attribute).join(db.UpdateAttribute).where(db.UpdateAttribute.update_id == id)
+        )
+
+    def insert_linked_attribute(self, id: UUID, attribute_id: UUID):
+        return insert(db.UpdateAttribute).values(update_id=id, attribute_id=attribute_id)

--- a/packages/data-core/src/movici_data_core/database/repository/updates.py
+++ b/packages/data-core/src/movici_data_core/database/repository/updates.py
@@ -20,7 +20,22 @@ from .common import EntityDataProcessor, EntityDataSelector, SQLResourceReposito
 
 @dataclasses.dataclass
 class UpdateRepository(SQLResourceRepository):
-    scenario_id: UUID
+    """A Repository for managing Updates. In contrast to other resources, Updates are immutable and
+    can only be created (added to a scenario). The only way to delete an update is by deleting all
+    updates for a Scenario, thereby effectively resetting the Scenario
+
+    :param scenario_id: A Scenario UUID to bind this UpdateRepository to. Most methods require the
+        repository to be bound, with the exception of :meth:`UpdateRepository.get_by_id`. Binding
+        generally is performed by the ``SQLAlchemyRepository`` that manages this
+        ``UpdateRepository``
+    """
+
+    scenario_id: UUID | None
+
+    def _ensure_scenario_id(self):
+        if self.scenario_id is None:
+            raise ValueError("UpdateRepository.scenario_id is required")
+        return self.scenario_id
 
     @property
     def selector(self):
@@ -30,15 +45,22 @@ class UpdateRepository(SQLResourceRepository):
         )
 
     async def list(self) -> list[Update]:
+        """List all updates in the active scenario.
+
+        :return: a list of Updates, these Updates do not contain any data
+        """
+        scenario_id = self._ensure_scenario_id()
         result = await self.session.scalars(
-            self.selector.where(db.Update.scenario_id == self.scenario_id).order_by(
+            self.selector.where(db.Update.scenario_id == scenario_id).order_by(
                 db.Update.timestamp, db.Update.iteration
             )
         )
         return [update.to_domain() for update in result]
 
-    async def exists(self):
-        return await self._exists(db.Update.scenario_id == self.scenario_id)
+    async def exists(self) -> bool:
+        """Does the active scenario have any updates?"""
+        scenario_id = self._ensure_scenario_id()
+        return await self._exists(db.Update.scenario_id == scenario_id)
 
     async def get_by_id(self, id: UUID, with_data=False) -> Update | None:
         record = await self.session.scalar(self.selector.where(db.Update.id == id))
@@ -46,24 +68,28 @@ class UpdateRepository(SQLResourceRepository):
             return None
         result = record.to_domain()
         if with_data:
-            result = dataclasses.replace(result, data=await self.get_data(id=id))
+            result = dataclasses.replace(result, data=await self._get_data(id=id))
         return result
 
-    async def get_data(self, id: UUID) -> dict:
+    async def _get_data(self, id: UUID) -> dict:
         return await EntityDataProcessor(
             self.session, all_data=self.all_data, selector=UpdateDataSelector()
         ).get(id)
 
     async def create(self, obj: Update) -> UUID:
         """
-        :param parent: A Scenario id
+        Store an Update to the active scenario.
+
+        :param obj: the Update to add, including data
+        :return: the newly created Update UUID
         """
+        scenario_id = self._ensure_scenario_id()
         if not isinstance(obj.data, dict):
             raise InvalidAction("update data must be a numpy dataset dict")
         model_type_id = await self.session.scalar(
             select(db.ModelType.id)
             .join(db.ScenarioModel)
-            .where(db.ScenarioModel.scenario_id == self.scenario_id)
+            .where(db.ScenarioModel.scenario_id == scenario_id)
             .where(db.ScenarioModel.name == obj.model_name)
         )
         if model_type_id is None:
@@ -74,7 +100,7 @@ class UpdateRepository(SQLResourceRepository):
             select(db.Dataset)
             .options(joinedload(db.Dataset.dataset_type))
             .join(db.ScenarioDataset)
-            .where(db.ScenarioDataset.scenario_id == self.scenario_id)
+            .where(db.ScenarioDataset.scenario_id == scenario_id)
             .where(db.Dataset.name == obj.dataset.name)
         )
         if dataset is None:
@@ -85,7 +111,7 @@ class UpdateRepository(SQLResourceRepository):
             await self.session.scalar(
                 insert(db.Update)
                 .values(
-                    scenario_id=self.scenario_id,
+                    scenario_id=scenario_id,
                     timestamp=obj.timestamp,
                     iteration=obj.iteration,
                     model_type_id=model_type_id,
@@ -101,12 +127,17 @@ class UpdateRepository(SQLResourceRepository):
         return update_id
 
     async def delete_all(self):
-        await self.session.execute(
-            delete(db.Update).where(db.Update.scenario_id == self.scenario_id)
-        )
+        """Delete all updates for the active scenario. Should be combined with a separate call, to
+        the Scenario, resetting the ScenarioStatus
+        """
+
+        scenario_id = self._ensure_scenario_id()
+        await self.session.execute(delete(db.Update).where(db.Update.scenario_id == scenario_id))
 
 
 class UpdateDataSelector(EntityDataSelector):
+    """Subclass of EntityDataSelector to be use for Updates"""
+
     def select_linked_attribute(self, id: UUID):
         return (
             select(db.Attribute).join(db.UpdateAttribute).where(db.UpdateAttribute.update_id == id)

--- a/packages/data-core/src/movici_data_core/database/repository/updates.py
+++ b/packages/data-core/src/movici_data_core/database/repository/updates.py
@@ -132,6 +132,15 @@ class UpdateRepository(SQLResourceRepository):
         """
 
         scenario_id = self._ensure_scenario_id()
+        await self.session.execute(
+            delete(db.Attribute).where(
+                db.Attribute.id.in_(
+                    select(db.UpdateAttribute.attribute_id)
+                    .join(db.Update)
+                    .where(db.Update.scenario_id == scenario_id)
+                )
+            )
+        )
         await self.session.execute(delete(db.Update).where(db.Update.scenario_id == scenario_id))
 
 

--- a/packages/data-core/src/movici_data_core/database/repository/workspace.py
+++ b/packages/data-core/src/movici_data_core/database/repository/workspace.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import dataclasses
+import typing as t
+from uuid import UUID
+
+from sqlalchemy import func, insert, select, update
+
+from movici_data_core.database import model as db
+from movici_data_core.domain_model import Workspace
+
+from .common import GenericResourceRepository, ensure_valid_id
+
+
+class WorkspaceRepository(GenericResourceRepository[Workspace]):
+    __resource__ = db.Workspace
+    __resource_type_name__ = "workspace"
+
+    async def list(self) -> list[Workspace]:
+        result = await super().list()
+
+        dataset_counts: dict[UUID, int] = {
+            k: v
+            for k, v in await self.session.execute(
+                select(db.Workspace.id, func.count(db.Dataset.id))
+                .join(db.Dataset)
+                .group_by(db.Workspace.id)
+            )
+        }
+        scenario_counts: dict[UUID, int] = {
+            k: v
+            for k, v in await self.session.execute(
+                select(db.Workspace.id, func.count(db.Scenario.id))
+                .join(db.Scenario)
+                .group_by(db.Workspace.id)
+            )
+        }
+        return [
+            dataclasses.replace(
+                ws,
+                dataset_count=dataset_counts.get(t.cast(UUID, ws.id), 0),
+                scenario_count=scenario_counts.get(t.cast(UUID, ws.id), 0),
+            )
+            for ws in result
+        ]
+
+    async def with_counts(self, workspace: Workspace) -> Workspace:
+        assert workspace.id is not None
+        return dataclasses.replace(
+            workspace,
+            dataset_count=t.cast(
+                int,
+                await self.session.scalar(
+                    select(func.count(1)).where(db.Dataset.workspace_id == workspace.id)
+                ),
+            ),
+            scenario_count=t.cast(
+                int,
+                await self.session.scalar(
+                    select(func.count(1)).where(db.Scenario.workspace_id == workspace.id)
+                ),
+            ),
+        )
+
+    async def create(self, obj: Workspace) -> UUID:
+
+        return t.cast(
+            UUID,
+            await self.session.scalar(
+                insert(db.Workspace)
+                .values(name=obj.name, display_name=obj.display_name)
+                .returning(db.Workspace.id)
+            ),
+        )
+
+    @ensure_valid_id
+    async def update(self, id: UUID, obj: Workspace):
+        await self.session.execute(
+            update(db.Workspace)
+            .where(db.Workspace.id == id)
+            .values(name=obj.name, display_name=obj.display_name)
+        )

--- a/packages/data-core/src/movici_data_core/database/repository/workspace.py
+++ b/packages/data-core/src/movici_data_core/database/repository/workspace.py
@@ -45,6 +45,9 @@ class WorkspaceRepository(GenericResourceRepository[Workspace]):
         ]
 
     async def with_counts(self, workspace: Workspace) -> Workspace:
+        """add :attr:`Workspace.dataset_count` and :attr:`Workspace.scenario_count` to the
+        workspace. The workspace must have been previously loaded from the database
+        """
         assert workspace.id is not None
         return dataclasses.replace(
             workspace,
@@ -63,7 +66,11 @@ class WorkspaceRepository(GenericResourceRepository[Workspace]):
         )
 
     async def create(self, obj: Workspace) -> UUID:
+        """Store a :class:``Workspace`` in the database
 
+        :param obj: the ``Workspace`` object
+        :return: the UUID of the stored ``ModelType``
+        """
         return t.cast(
             UUID,
             await self.session.scalar(
@@ -75,6 +82,13 @@ class WorkspaceRepository(GenericResourceRepository[Workspace]):
 
     @ensure_valid_id
     async def update(self, id: UUID, obj: Workspace):
+        """Update a :class:``Workspace`` in the database
+
+        Valid fields to update are: ``name``, ``display_name``
+
+        :param id: the UUID of the stored ``Workspace``
+        :param obj: the ``Workspace`` object with the changes
+        """
         await self.session.execute(
             update(db.Workspace)
             .where(db.Workspace.id == id)

--- a/packages/data-core/src/movici_data_core/domain_model.py
+++ b/packages/data-core/src/movici_data_core/domain_model.py
@@ -211,7 +211,6 @@ class Update:
 
     id: UUID | None = None
     created_at: datetime.datetime | None = None
-    updated_at: datetime.datetime | None = None
     data: DatasetData | None = None
 
 

--- a/packages/data-core/src/movici_data_core/domain_model.py
+++ b/packages/data-core/src/movici_data_core/domain_model.py
@@ -175,7 +175,6 @@ class ScenarioModel:
     name: str
     type: ModelType
     config: dict = dataclasses.field(default_factory=dict)
-    id: UUID | None = dataclasses.field(compare=False, default=None)
     references: list[MoviciDataRefInfo] = dataclasses.field(default_factory=list, compare=False)
 
 

--- a/packages/data-core/src/movici_data_core/domain_model.py
+++ b/packages/data-core/src/movici_data_core/domain_model.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+import enum
+import pathlib
+import typing as t
+from uuid import UUID
+
+from movici_simulation_core.core import AttributeSpec, DataType
+from movici_simulation_core.validate import MoviciDataRefInfo
+
+
+class DatasetFormat(str, enum.Enum):
+    """Format types for dataset storage.
+
+    Matches the ``format`` field used in the platform:
+
+    * ``ENTITY_BASED``: Entity-oriented JSON data, destructured into numpy arrays
+    * ``UNSTRUCTURED``: Unstructured JSON data, stored as blob but JSON-loadable
+    * ``BINARY``: Binary data, stored as blob and passed transparently
+    """
+
+    ENTITY_BASED = "entity_based"
+    UNSTRUCTURED = "unstructured"
+    BINARY = "binary"
+    UNKNOWN = "unknown"
+
+
+class ScenarioStatus(str, enum.Enum):
+    FAILED = "Failed"
+    INVALID = "Invalid"
+    READY = "Ready"
+    RUNNING = "Running"
+    SUCCEEDED = "Succeeded"
+
+
+AttributeDataType = type[bool | int | float | str]
+
+
+def utcnow():
+    return datetime.datetime.now(tz=datetime.UTC)
+
+
+@dataclasses.dataclass
+class Workspace:
+    name: str
+    display_name: str
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+    scenario_count: int | None = None
+    dataset_count: int | None = None
+
+
+@dataclasses.dataclass
+class DatasetType:
+    name: str
+    format: DatasetFormat
+    mimetype: str | None = None
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+
+
+@dataclasses.dataclass
+class EntityType:
+    name: str
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+
+
+@dataclasses.dataclass
+class AttributeType:
+    name: str
+    data_type: DataType
+
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+
+    unit: str = ""
+    description: str = ""
+    enum_name: str | None = None
+
+    @classmethod
+    def from_attribute_spec(cls, spec: AttributeSpec):
+        return cls(name=spec.name, data_type=spec.data_type, enum_name=spec.enum_name)
+
+    def to_attribute_spec(self):
+        return AttributeSpec(name=self.name, data_type=self.data_type, enum_name=self.enum_name)
+
+
+@dataclasses.dataclass
+class ModelType:
+    name: str
+    jsonschema: dict
+
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+
+
+class BoundingBox(t.NamedTuple):
+    """Representation of a bounding box, if any of the components are ``None``, the bounding box
+    is considered incomplete and reduces to ``None``
+    """
+
+    min_x: float | None
+    min_y: float | None
+    max_x: float | None
+    max_y: float | None
+
+    @classmethod
+    def empty(cls) -> BoundingBox:
+        """Return an empty BoundingBox (all fields set to None) that can be use as a basis for
+        generating a bounding box from multiple datasets/updates
+        """
+        return BoundingBox(None, None, None, None)
+
+    def as_tuple_or_none(self):
+        if self.min_x is None or self.min_y is None or self.max_x is None or self.max_y is None:
+            return None
+        return self
+
+
+@dataclasses.dataclass
+class Scenario:
+    name: str
+    display_name: str
+    description: str
+
+    epsg_code: int
+    bounding_box: BoundingBox = dataclasses.field(default_factory=BoundingBox.empty)
+    simulation_info: dict = dataclasses.field(default_factory=dict)
+    status: ScenarioStatus = ScenarioStatus.READY
+
+    id: UUID | None = None
+    workspace: Workspace | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    models: list[dict] = dataclasses.field(default_factory=list)
+    datasets: list[dict] = dataclasses.field(default_factory=list)
+    has_updates: bool = False
+
+
+@dataclasses.dataclass
+class ScenarioDataset:
+    name: str
+    type: str
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+
+
+@dataclasses.dataclass
+class ScenarioModel:
+    name: str
+    type: ModelType
+    config: dict = dataclasses.field(default_factory=dict)
+    id: UUID | None = dataclasses.field(compare=False, default=None)
+    references: list[MoviciDataRefInfo] = dataclasses.field(default_factory=list, compare=False)
+
+
+DatasetData = dict | bytes | t.BinaryIO | pathlib.Path
+
+
+@dataclasses.dataclass
+class Dataset:
+    name: str
+    display_name: str
+    dataset_type: DatasetType
+    id: UUID | None = None
+    workspace: Workspace | None = None
+
+    general: dict | None = None
+    epsg_code: int | None = None
+    bounding_box: BoundingBox = dataclasses.field(default_factory=BoundingBox.empty)
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+
+    data: DatasetData | None = None
+    has_data: bool = False
+
+
+@dataclasses.dataclass
+class Update:
+    dataset: ScenarioDataset
+    timestamp: int
+    iteration: int
+
+    model_name: str
+    model_type: str | None = None
+
+    id: UUID | None = None
+    created_at: datetime.datetime | None = None
+    updated_at: datetime.datetime | None = None
+    data: DatasetData | None = None
+
+
+@dataclasses.dataclass
+class DatasetSummary:
+    general: dict
+    epsg_code: int | None
+    bounding_box: BoundingBox
+    entity_groups: list[EntityGroupSummary]
+    count: int
+
+
+@dataclasses.dataclass
+class EntityGroupSummary:
+    name: str
+    count: int
+    attributes: list[AttributeSummary]
+
+
+T_datatype = t.TypeVar("T_datatype", bool, int, float, str)
+
+
+@dataclasses.dataclass
+class AttributeSummary(t.Generic[T_datatype]):
+    name: str
+    data_type: DataType[T_datatype]
+    description: str
+    enum_name: str | None
+    unit: str
+    min_val: T_datatype | None
+    max_val: T_datatype | None

--- a/packages/data-core/src/movici_data_core/domain_model.py
+++ b/packages/data-core/src/movici_data_core/domain_model.py
@@ -116,6 +116,34 @@ class BoundingBox(t.NamedTuple):
 
 
 @dataclasses.dataclass
+class SimulationInfo:
+    """A class to hold information about the time settings of the scenario. In a simulation, time
+    progresses in discrete intervals, each with a time step of ``time_scale`` seconds. The total
+    duration of the simulation is ``duration`` discrete intervals. The simulation starts at the
+    discrete time step ``start_time``. For purposes of calculating the absolute (wall clock) time
+    in the simulation, at ``t=start_time``, the absolute time has a unix timestamp
+    ``reference``
+
+    :param duration: the duration of the scenario in discrete time steps
+    :param reference: the unix timestamp inside the simulation at ``t=0``
+    :param time_scale: the size of a single discrete timestep in seconds. Default: ``1``
+    :param start_time: the discrete time step to start the simulation at, usually ``t=0``.
+      default: ``0``
+    :param mode: must be set to ``"time_oriented". Default ``"time_oriented"``
+    """
+
+    duration: int
+    reference: float
+    time_scale: float = 1
+    start_time: int = 0
+    mode: t.Literal["time_oriented"] = "time_oriented"
+
+    @classmethod
+    def default(cls):
+        return cls(reference=0, duration=1)
+
+
+@dataclasses.dataclass
 class Scenario:
     name: str
     display_name: str
@@ -123,7 +151,7 @@ class Scenario:
 
     epsg_code: int
     bounding_box: BoundingBox = dataclasses.field(default_factory=BoundingBox.empty)
-    simulation_info: dict = dataclasses.field(default_factory=dict)
+    simulation_info: SimulationInfo = dataclasses.field(default_factory=SimulationInfo.default)
     status: ScenarioStatus = ScenarioStatus.READY
 
     id: UUID | None = None

--- a/packages/data-core/src/movici_data_core/domain_model.py
+++ b/packages/data-core/src/movici_data_core/domain_model.py
@@ -16,9 +16,13 @@ class DatasetFormat(str, enum.Enum):
 
     Matches the ``format`` field used in the platform:
 
-    * ``ENTITY_BASED``: Entity-oriented JSON data, destructured into numpy arrays
-    * ``UNSTRUCTURED``: Unstructured JSON data, stored as blob but JSON-loadable
-    * ``BINARY``: Binary data, stored as blob and passed transparently
+    * ``ENTITY_BASED``: Entity-oriented JSON data, destructured into numpy arrays. Entity data is
+      split up into entity groups that contain attributes. see also :ref:`movici-data-format`
+    * ``UNSTRUCTURED``: Unstructured JSON data, stored as blob but JSON-loadable. A Dataset with
+      ``UNSTRUCTURED`` data contains a ``"data"`` sections that can be JSON encoded, but is
+      otherwise schemaless
+    * ``BINARY``: Binary data, stored as blob and passed transparently. A Dataset with ``BINARY``
+      data can contain any data that is not validated by ``movici-data-core``
     """
 
     ENTITY_BASED = "entity_based"
@@ -27,6 +31,13 @@ class DatasetFormat(str, enum.Enum):
     UNKNOWN = "unknown"
 
 
+# TODO: implement proper usage of scenariostatus. Invalid/Ready is managed internally based on the
+# availability of data (do all the scenariodatasets have data?) while the other statuses need an
+# external source, or an (api) endpoint that can set them, based on a simulation that is running
+# or has completed (succesfully or not)
+# Perhaps we also need to think about what happens if simulation just stops reporting about the
+# Scenario. Do we want to trigger setting a scenario status to Failed if a simulation has not
+# updated a scenario for a certain time, either by posting an update or (re)posting the status
 class ScenarioStatus(str, enum.Enum):
     FAILED = "Failed"
     INVALID = "Invalid"
@@ -44,6 +55,17 @@ def utcnow():
 
 @dataclasses.dataclass
 class Workspace:
+    """A Workspace is a logical unit for bundling Scenarios and Datasets. A Scenario must be in the
+    same Workspace as any Dataset it references. Workspaces may group Scenarios and Datasets that
+    belong to a certain project, organisation or that otherwise logically belong together.
+
+    :param name: a *snake_case* workspace name, must be unique in the database
+    :param display_name: a human readably display name
+    :param id: the workspace ``UUID`` in the database (if any)
+    :param scenario_count: the number of scenarios in this workspace
+    :param dataset_count: the number of datasets in this workspace
+    """
+
     name: str
     display_name: str
     id: UUID | None = dataclasses.field(compare=False, default=None)
@@ -53,6 +75,14 @@ class Workspace:
 
 @dataclasses.dataclass
 class DatasetType:
+    """A DatasetType determines the meaning of a Dataset. Every Dataset must have a type. Examples
+    may be ``transport_network`` or ``tabular``
+    :param name: a *snake_case* name, must be unique in the database
+    :param format: determines how Dataset data is formatted
+    :param mimetype: in case of a ``DatasetFormat.BINARY`` format, a dataset type may
+      specify a mimetype. When adding data, the mimetype may be validated if given
+    """
+
     name: str
     format: DatasetFormat
     mimetype: str | None = None
@@ -61,12 +91,31 @@ class DatasetType:
 
 @dataclasses.dataclass
 class EntityType:
+    """Representation of an entity type
+
+    :param name: a *snake_case* name, must be unique in the database
+    :param id: the entity type ``UUID`` in the database (if any)
+    """
+
     name: str
     id: UUID | None = dataclasses.field(compare=False, default=None)
 
 
 @dataclasses.dataclass
 class AttributeType:
+    """
+    An attribute type contains information about an attribute. Every attribute must have a type.
+    Equivalent to an :ref:`AttributeSpec` and can be converted to and from :ref:`AttributeSpec`
+
+    :param name: a *snake_case* name for the attribute type. Must be unique in the database
+    :param data_type: The data type of the attribute
+    :param id: the attribute type ``UUID`` in the database (if any)
+    :param unit: the unit of the attribute, such as ``m`` or ``s``. Default ``""`` (emtpy string)
+    :param description: a description of the attribute describing it's meaning. Default
+      ``""`` (empty string)
+    :param enum_name: (Optional) in case of an ``enum`` attribute, the name of the ``enum``
+    """
+
     name: str
     data_type: DataType
 
@@ -78,14 +127,27 @@ class AttributeType:
 
     @classmethod
     def from_attribute_spec(cls, spec: AttributeSpec):
+        """Convert an :ref:`AttributeSpec` to an :ref:`AttributeType`"""
         return cls(name=spec.name, data_type=spec.data_type, enum_name=spec.enum_name)
 
     def to_attribute_spec(self):
+        """Convert an :ref:`AttributeType` to an :ref:`AttributeSpec`"""
         return AttributeSpec(name=self.name, data_type=self.data_type, enum_name=self.enum_name)
 
 
 @dataclasses.dataclass
 class ModelType:
+    """A model type is a definition of a model that may be used in a ``Scenario``. It must contain
+    a jsonschema that validates model configs for that type in the ``Scenario`` config
+
+    :param name: a *snake_case* name, must be unique in the database
+    :param jsonschema: a ``jsonschema`` dict to validate any model configs for this model
+      type. The json schema may contain movici custom keys such as ``movici.type`` and
+      ``movici.datasetType``, to indicate a field is a reference to a Movici object such as a
+      ``Dataset``,  ``EntityType`` or ``AttributeType``
+    :param id: the model type ``UUID`` in the database (if any)
+    """
+
     name: str
     jsonschema: dict
 
@@ -145,6 +207,25 @@ class SimulationInfo:
 
 @dataclasses.dataclass
 class Scenario:
+    r"""A Scenario is a description of a simulation. It contains a collection of models that should
+    work togehter on a collection of datasets in order to perform a certain, specific, calculation,
+    as well as other information such as the timeline information
+
+    :param name: a *snake_case* name, must be unique in the workspace
+    :param display_name: a human readable display name
+    :param description: a human readable description of the scenario
+    :param epsg_code: The coordinate reference system (as an EPSG code) of the scenario
+    :param bounding_box: the scenario bounding box (output only)
+    :param simulation_info: the scenario simulation info
+    :param status: the scenario status
+    :param id: the scenario ``UUID`` in the database (if any)
+    :param workspace: The workspace the scenario belongs to (if any)
+    :param created_at: the datetime the scenario was created
+    :param updated_at: the datetime the scenario was updated
+    :param models: a list of model config dicts for this scenario
+    :param datasets: a list of datasets for this scenario
+    """
+
     name: str
     display_name: str
     description: str
@@ -158,6 +239,7 @@ class Scenario:
     workspace: Workspace | None = None
     created_at: datetime.datetime | None = None
     updated_at: datetime.datetime | None = None
+    # TODO: Use ScenarioModel and ScenarioDataset here
     models: list[dict] = dataclasses.field(default_factory=list)
     datasets: list[dict] = dataclasses.field(default_factory=list)
     has_updates: bool = False
@@ -165,6 +247,13 @@ class Scenario:
 
 @dataclasses.dataclass
 class ScenarioDataset:
+    """A representation of a dataset in a scenario
+
+    :param name: the dataset name
+    :param type: the dataset dataset type
+    :param id: the dataset ``UUID`` in the database (if any)
+    """
+
     name: str
     type: str
     id: UUID | None = dataclasses.field(compare=False, default=None)
@@ -172,6 +261,15 @@ class ScenarioDataset:
 
 @dataclasses.dataclass
 class ScenarioModel:
+    """A configured model in a scenario
+
+    :param name: a *snake_case* model name. Must be unique in a scenario
+    :param type: the model type
+    :param config: the model config dict
+    :param references: a list of :ref:`MoviciDataRefInfo` objects that were extracted from the
+        model config dict
+    """
+
     name: str
     type: ModelType
     config: dict = dataclasses.field(default_factory=dict)
@@ -183,6 +281,23 @@ DatasetData = dict | bytes | t.BinaryIO | pathlib.Path
 
 @dataclasses.dataclass
 class Dataset:
+    """
+    :param name: a *snake_case* dataset name, must be unique in the Workspace
+    :param display_name: a human readable display name
+    :param dataset_type: the dataset's type
+    :param id: the dataset ``UUID`` in the database (if any)
+    :param workspace: the :ref:`Workspace` the dataset belongs to (if any)
+    :param general: the dataset's general section (dict) for ``ENTITY_BASED`` and ``UNSTRUCTURED``
+        datasets (if any)
+    :param epsg_code: the dataset's CRS as an EPSG code
+    :param bounding_box: the datasets :class:`BoundingBox` if it contains geospatial data (output
+        only)
+    :param created_at: the datetime the dataset was created
+    :param updated_at: the datetime the dataset was updated
+    :param data: the dataset's data, if presented or loaded
+    :param has_data: whether the dataset has data in the database
+    """
+
     name: str
     display_name: str
     dataset_type: DatasetType
@@ -201,10 +316,25 @@ class Dataset:
 
 @dataclasses.dataclass
 class Update:
+    """An Update is a change to the :term:`World State` in a simulation. An update is always
+    produced by a model at a certain timestamp
+
+    :param dataset: The dataset this update changes the state for
+    :param timestamp: the discrete time step this update was produced in the simulation
+    :param iteration: the iteration at the timestamp this update was created. Every update in a
+        scenario must have a unique (timestamp, iteration) combination
+    :param model_name: the name of the model in the scenario that produced the update
+    :param model_type: the type of the model in the scenario that produced the update
+    :param id: the update ``UUID`` in the database (if any)
+    :param created_at: the datetime the update was created
+    :param data: the update data payload
+    """
+
     dataset: ScenarioDataset
     timestamp: int
     iteration: int
 
+    # TODO: use ScenarioModel here
     model_name: str
     model_type: str | None = None
 
@@ -215,6 +345,17 @@ class Update:
 
 @dataclasses.dataclass
 class DatasetSummary:
+    """A DatasetSummary is an overview of the entity groups and attributes in a (``ENTITY_BASED``
+    dataset. It also contains some other information, such as the dataset general section as well
+    as the EPSG code and bounding box. A ``DatasetSummary`` is an output only object
+
+    :param general: the dataset general section
+    :param epsg_code: the dataset's CRS as an EPSG code
+    :param bounding_box: the dataset's :class:`BoundingBox` if it contains geospatial data
+    :param entity_groups: a summary of the entity groups in the dataset
+    :param count: the total number of entities in the dataset
+    """
+
     general: dict
     epsg_code: int | None
     bounding_box: BoundingBox
@@ -224,6 +365,14 @@ class DatasetSummary:
 
 @dataclasses.dataclass
 class EntityGroupSummary:
+    """an entry in the :attr:`DatasetSummary.entity_groups` list. Contains a summary of a single
+    entity group.
+
+    :param name: the entity group name (equal to its type)
+    :param count: the number of entities in this entity group
+    :param attributes: a summary of the attributes in the entity groups
+    """
+
     name: str
     count: int
     attributes: list[AttributeSummary]
@@ -232,8 +381,21 @@ class EntityGroupSummary:
 T_datatype = t.TypeVar("T_datatype", bool, int, float, str)
 
 
+# TODO: Reuse fields from AttributeType, perhaps introducing a BaseAttributeType class
 @dataclasses.dataclass
 class AttributeSummary(t.Generic[T_datatype]):
+    """an entry in the :attr:`EntityGroupSummary.entity_groups` list. Contains a summary of a
+    single entity group.
+
+    :param name: the attribute name (equal to its type)
+    :param data_type: the attribute's data type
+    :param description: the attribute type's description
+    :param enum_name: the attribute type's enum name (if any)
+    :param unit: the attributes type's unit
+    :param min_val: the minimum value of the attribute for the associated entity group (if any)
+    :param max_val: the maximum value of the attribute for the associated entity group (if any)
+    """
+
     name: str
     data_type: DataType[T_datatype]
     description: str

--- a/packages/data-core/src/movici_data_core/exceptions.py
+++ b/packages/data-core/src/movici_data_core/exceptions.py
@@ -190,6 +190,13 @@ T = t.TypeVar("T")
 
 
 class map_errors:
+    """A decorator to catch certain exceptions and reraise them as a different exception
+
+    :param mapping: a mapping between exceptions or exception types and a callable per exception
+       or exception type. The callable must accept the same arguments as the decorated method
+       except the ``self`` argument
+    """
+
     def __init__(
         self,
         mapping: t.Mapping[

--- a/packages/data-core/src/movici_data_core/exceptions.py
+++ b/packages/data-core/src/movici_data_core/exceptions.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import functools
+import inspect
+import typing as t
+from http import HTTPStatus
+from uuid import UUID
+
+from jsonschema import ValidationError as JSONSchemaValidationError
+
+from movici_simulation_core.types import FileType
+
+
+class MoviciDataError(Exception):
+    __status_code__ = HTTPStatus.INTERNAL_SERVER_ERROR
+    __error_message__ = "An error occured"
+    __error_id__ = "generic_error"
+
+    def payload(self) -> dict | None:
+        pass
+
+
+class DatabaseAlreadyInitialized(MoviciDataError):
+    pass
+
+
+class DatabaseNotYetInitialized(MoviciDataError):
+    pass
+
+
+class InconsistentDatabase(MoviciDataError):
+    pass
+
+
+class InvalidResource(MoviciDataError):
+    __status_code__ = HTTPStatus.BAD_REQUEST
+    __error_id__ = "invalid_resource"
+    __error_message__ = "Invalid resource"
+    id: UUID | None
+
+    def __init__(
+        self,
+        resource_type: str,
+        name: str | None = None,
+        id: UUID | None = None,
+        message: str | None = None,
+    ):
+        if not (name or id):
+            raise ValueError("Supply at least one of name or id")
+        self.resource_type = resource_type
+        self.name = name
+        self.id = id
+        self.message = message
+
+    def __str__(self) -> str:
+        parts = [self.resource_type]
+        if self.name is not None:
+            parts.append(f'(name="{self.name}")')
+        if self.id is not None:
+            parts.append(f"(id={self.id})")
+        if self.message is not None:
+            parts.append(f"[{self.message}]")
+        return " ".join(parts)
+
+    def payload(self):
+        return {
+            "resource": self.resource_type,
+            "name": self.name,
+            "id": self.id,
+            "message": self.message or self.__error_message__,
+        }
+
+
+class InvalidID(MoviciDataError):
+    __status_code__ = HTTPStatus.NOT_FOUND
+    __error_id__ = "id_not_found"
+
+    def __init__(self, id: t.Any):
+        self.id = id
+
+    def payload(self) -> dict | None:
+        return {"message": f"ID {self.id} is not a valid id "}
+
+
+class UnsupportedFileType(MoviciDataError):
+    __status_code__ = HTTPStatus.UNSUPPORTED_MEDIA_TYPE
+    __error_id__ = "unsupported_media_type"
+
+    def __init__(self, filetype: FileType):
+        self.filetype = filetype
+
+    def payload(self):
+        return {"message": f"Filetype {self.filetype} is not supported for this operation"}
+
+
+class DeserializationError(MoviciDataError):
+    __status_code__ = HTTPStatus.BAD_REQUEST
+    __error_id__ = "invalid_data"
+    __error_message__ = "Error while reading data"
+
+
+class MoviciValidationError(MoviciDataError):
+    __status_code__ = HTTPStatus.UNPROCESSABLE_CONTENT
+    __error_id__ = "validation_error"
+    __error_message__ = "Valdation error"
+
+    def __init__(self, error: str | dict[str, list[str]] | None = None, path=""):
+        self.path = path
+        if isinstance(error, str):
+            error = {"": [error]}
+        self.messages: dict[str, list[str]] = error or {}
+
+    @classmethod
+    def from_errors(
+        cls,
+        errors: t.Sequence[JSONSchemaValidationError | MoviciValidationError]
+        | JSONSchemaValidationError
+        | MoviciValidationError,
+        path="",
+    ):
+        result = MoviciValidationError(path=path)
+        result.consume(errors)
+        return result
+
+    def consume(
+        self,
+        errors: t.Sequence[JSONSchemaValidationError | MoviciValidationError]
+        | JSONSchemaValidationError
+        | MoviciValidationError,
+    ):
+        if isinstance(errors, (JSONSchemaValidationError, MoviciValidationError)):
+            return self.consume([errors])
+        for error in errors:
+            if isinstance(error, JSONSchemaValidationError):
+                path = ".".join(str(p) for p in error.path)
+                messages = self.messages.setdefault(path, [])
+                messages.append(error.message)
+            if isinstance(error, MoviciValidationError):
+                self.messages.update(error.as_dict())
+
+    def as_dict(self):
+        result = {}
+        for k, msg in self.iter_messages():
+            result.setdefault(k, []).append(msg)
+        return result
+
+    def iter_messages(self):
+        prefix = self.path + "." if self.path else ""
+        for key, messages in self.messages.items():
+            if not key:
+                path = self.path
+            else:
+                path = prefix + key
+            for message in messages:
+                yield path, message
+
+    def __str__(self):
+        return "\n".join(f"{p}: {msg}" for p, msg in self.iter_messages())
+
+    def as_http_payload(self):
+        return {
+            "messages": self.as_dict(),
+        }
+
+
+class ResourceDoesNotExist(InvalidResource):
+    __status_code__ = HTTPStatus.NOT_FOUND
+    __error_id__ = "not_found"
+    __error_message__ = "Resource not found"
+
+
+class ResourceAlreadyExists(InvalidResource):
+    __status_code__ = HTTPStatus.CONFLICT
+    __error_id__ = "duplicate_error"
+    __error_message__ = "Resource already exists"
+
+
+class InvalidAction(MoviciDataError):
+    __status_code__ = HTTPStatus.BAD_REQUEST
+    __error_id__ = "invalid_action"
+
+    def __init__(self, message: str = "Invalid action"):
+        self.message = message
+
+    def payload(self) -> dict | None:
+        return {"message": self.message}
+
+
+T = t.TypeVar("T")
+
+
+class map_errors:
+    def __init__(
+        self,
+        mapping: t.Mapping[
+            type[Exception], Exception | type[Exception] | t.Callable[..., Exception]
+        ],
+    ):
+        self.mapping = mapping
+
+    def __call__(self, func: T) -> T:
+        if inspect.iscoroutinefunction(func):
+            return self.wrap_async(func)
+        return t.cast(T, self.wrap(func))
+
+    def wrap(self, func):
+        @functools.wraps(func)
+        def _wrapped(inst, *args, **kwargs):
+            try:
+                return func(inst, *args, **kwargs)
+            except Exception as e:
+                raise self._map_error(e, args, kwargs) from e
+
+        return _wrapped
+
+    def wrap_async(self, func):
+        @functools.wraps(func)
+        async def _wrapped(inst, *args, **kwargs):
+            try:
+                return await func(inst, *args, **kwargs)
+            except Exception as e:
+                raise self._map_error(e, args, kwargs) from e
+            except BaseException:
+                raise
+
+        return _wrapped
+
+    def _map_error(
+        self, exc: type[Exception] | Exception, args, kwargs
+    ) -> type[Exception] | Exception:
+        exc_type = type(exc) if isinstance(exc, Exception) else exc
+        if exc_type in self.mapping:
+            mapped = self.mapping[exc_type]
+            if callable(mapped):
+                mapped = mapped(*args, **kwargs)
+            return mapped
+        return exc

--- a/packages/data-core/src/movici_data_core/validators.py
+++ b/packages/data-core/src/movici_data_core/validators.py
@@ -1,0 +1,122 @@
+import dataclasses
+import typing as t
+
+from movici_data_core.domain_model import (
+    AttributeType,
+    EntityType,
+    ModelType,
+    ScenarioDataset,
+    ScenarioModel,
+)
+from movici_data_core.exceptions import MoviciValidationError
+from movici_simulation_core.validate import MoviciTypeLookup, ensure_schema, validate_and_process
+
+
+@dataclasses.dataclass
+class ModelConfigValidator:
+    attribute_types: dict[str, AttributeType] = dataclasses.field(default_factory=dict)
+    entity_types: dict[str, EntityType] = dataclasses.field(default_factory=dict)
+    datasets: dict[str, ScenarioDataset] | None = None
+    model_types: dict[str, ModelType] | None = None
+    dataset_types_by_datasets: dict[str, str] | None = dataclasses.field(init=False)
+
+    def __post_init__(self):
+        self.dataset_types_by_datasets = (
+            {ds.name: ds.type for ds in self.datasets.values()} if self.datasets else None
+        )
+
+    @classmethod
+    def from_list_data(
+        cls,
+        attribute_types: t.Sequence[AttributeType],
+        entity_types: t.Sequence[EntityType],
+        datasets: t.Sequence[ScenarioDataset] | None = None,
+    ):
+        return cls(
+            attribute_types={attr.name: attr for attr in attribute_types},
+            entity_types={et.name: et for et in entity_types},
+            datasets={ds.name: ds for ds in datasets} if datasets is not None else None,
+        )
+
+    def for_scenario(
+        self, datasets: t.Sequence[ScenarioDataset], model_types: t.Sequence[ModelType]
+    ):
+        return dataclasses.replace(
+            self,
+            datasets={ds.name: ds for ds in datasets},
+            model_types={mt.name: mt for mt in model_types},
+        )
+
+    def validated_model_type(self, config: dict):
+        assert self.model_types is not None
+
+        if "type" not in config:
+            raise MoviciValidationError("type is a required field")
+
+        model_type = config["type"]
+        if not isinstance(model_type, str):
+            raise MoviciValidationError("must be string", path="type")
+
+        if model_type not in self.model_types:
+            raise MoviciValidationError(f"invalid model_type {model_type}", path="type")
+
+        return self.model_types[model_type]
+
+    @property
+    def lookup(self):
+        return MoviciTypeLookup(
+            attribute_types=self.attribute_types.keys(),
+            entity_types=self.entity_types.keys(),
+            datasets=self.dataset_types_by_datasets,
+        )
+
+    def process_model_configs(self, configs: list[dict]) -> list[ScenarioModel]:
+        assert self.model_types is not None
+        assert self.datasets is not None
+
+        errors: list[MoviciValidationError] = []
+        result: list[ScenarioModel] = []
+
+        for idx, config in enumerate(configs):
+            try:
+                model_type = self.validated_model_type(config)
+                result.append(self.parse_and_validate_model_config(config, model_type))
+            except MoviciValidationError as e:
+                errors.append(MoviciValidationError.from_errors(e, path=str(idx)))
+        if errors:
+            raise MoviciValidationError.from_errors(errors)
+        return result
+
+    def parse_and_validate_model_config(
+        self, config: dict, model_type: ModelType
+    ) -> ScenarioModel:
+        if "name" not in config:
+            raise MoviciValidationError("name is a required field")
+
+        name = config["name"]
+        if not isinstance(name, str):
+            raise MoviciValidationError("must be string", path="name")
+
+        refs, errors = validate_and_process(
+            config,
+            schema=ensure_schema(model_type.jsonschema),
+            lookup=self.lookup,
+            return_errors=True,
+        )
+        if not errors:
+            return ScenarioModel(name, type=model_type, config=config, references=refs)
+        raise MoviciValidationError.from_errors(errors)
+
+    def iter_scenario_model_references(self, scenario_model: ScenarioModel) -> t.Iterable[dict]:
+        for ref in scenario_model.references:
+            ref_data = {
+                "scenario_model_id": scenario_model.id,
+                "path": ref.json_path,
+            }
+            if ref.movici_type == "attribute":
+                ref_data["attribute_type_id"] = self.attribute_types[ref.value].id
+            elif ref.movici_type == "entityGroup":
+                ref_data["entity_type_id"] = self.entity_types[ref.value].id
+            elif ref.movici_type == "dataset":
+                ref_data["dataset_id"] = self.datasets[ref.value].id if self.datasets else None
+            yield ref_data

--- a/packages/data-core/src/movici_data_core/validators.py
+++ b/packages/data-core/src/movici_data_core/validators.py
@@ -1,5 +1,6 @@
 import dataclasses
 import typing as t
+from uuid import UUID
 
 from movici_data_core.domain_model import (
     AttributeType,
@@ -107,10 +108,12 @@ class ModelConfigValidator:
             return ScenarioModel(name, type=model_type, config=config, references=refs)
         raise MoviciValidationError.from_errors(errors)
 
-    def iter_scenario_model_references(self, scenario_model: ScenarioModel) -> t.Iterable[dict]:
+    def iter_scenario_model_references(
+        self, id: UUID, scenario_model: ScenarioModel
+    ) -> t.Iterable[dict]:
         for ref in scenario_model.references:
             ref_data = {
-                "scenario_model_id": scenario_model.id,
+                "scenario_model_id": id,
                 "path": ref.json_path,
             }
             if ref.movici_type == "attribute":

--- a/packages/data-core/src/movici_data_core/validators.py
+++ b/packages/data-core/src/movici_data_core/validators.py
@@ -39,6 +39,8 @@ class ModelConfigValidator:
             datasets={ds.name: ds for ds in datasets} if datasets is not None else None,
         )
 
+    # TODO: Once a Scenario contains ScenarioDatasets and ScenarioModels, this method can take
+    # the scenario as an input argument
     def for_scenario(
         self, datasets: t.Sequence[ScenarioDataset], model_types: t.Sequence[ModelType]
     ):

--- a/packages/data-core/tests/conftest.py
+++ b/packages/data-core/tests/conftest.py
@@ -21,6 +21,7 @@ from movici_data_core.domain_model import (
     ModelType,
     Scenario,
     ScenarioDataset,
+    SimulationInfo,
     Update,
     Workspace,
 )
@@ -276,7 +277,7 @@ async def a_scenario(
         display_name="A Scenario",
         description="Scenario for testing",
         epsg_code=28992,
-        simulation_info={"some": "info"},
+        simulation_info=SimulationInfo.default(),
         datasets=[
             {
                 "name": a_dataset.name,

--- a/packages/data-core/tests/conftest.py
+++ b/packages/data-core/tests/conftest.py
@@ -300,4 +300,4 @@ async def a_scenario(
         ],
     )
     scenario_id = await create_scenario(scenario)
-    return t.cast(Scenario, await repository.scenarios.for_id(scenario_id).get_by_id())
+    return t.cast(Scenario, await repository.scenarios.for_id(scenario_id).get())

--- a/packages/data-core/tests/conftest.py
+++ b/packages/data-core/tests/conftest.py
@@ -1,0 +1,302 @@
+import typing as t
+from unittest.mock import patch
+from uuid import UUID
+
+import numpy as np
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from movici_data_core.database import model as db_model
+from movici_data_core.database.backend import SQLAlchemyServer
+from movici_data_core.database.general import get_options, initialize_database
+from movici_data_core.database.model import DatabaseMode
+from movici_data_core.database.repository import SQLAlchemyRepository
+from movici_data_core.database.repository.common import RawDataProcessor
+from movici_data_core.domain_model import (
+    AttributeType,
+    Dataset,
+    DatasetFormat,
+    DatasetType,
+    EntityType,
+    ModelType,
+    Scenario,
+    ScenarioDataset,
+    Update,
+    Workspace,
+)
+from movici_data_core.validators import ModelConfigValidator
+from movici_simulation_core.core import DataType
+
+
+@pytest.fixture
+def dbapi_url():
+    return "sqlite+aiosqlite://"
+
+
+@pytest.fixture
+def database_mode():
+    return DatabaseMode.MULTIPLE_WORKSPACES
+
+
+@pytest.fixture
+async def database_server(dbapi_url, tmp_path):
+    async with SQLAlchemyServer(dbapi_url, tmpfile_dir=tmp_path).begin() as server:
+        async with server.engine.begin() as conn:
+            await conn.run_sync(db_model.Base.metadata.create_all)
+        yield server
+
+
+@pytest.fixture
+async def initialized_db(database_server: SQLAlchemyServer, database_mode):
+    async with database_server.get_session() as session:
+        await initialize_database(session, mode=database_mode)
+        yield database_server
+
+
+@pytest.fixture
+async def session(initialized_db: SQLAlchemyServer):
+    async with initialized_db.get_session() as session:
+        yield session
+
+
+@pytest.fixture
+def default_dataset_types():
+    return [
+        DatasetType(name="transport_network", format=DatasetFormat.ENTITY_BASED),
+        DatasetType(
+            name="flooding_tape", format=DatasetFormat.BINARY, mimetype="application/x-netcdf"
+        ),
+        DatasetType(name="tabular", format=DatasetFormat.UNSTRUCTURED),
+    ]
+
+
+@pytest.fixture
+def default_entity_types():
+    return [
+        EntityType("roads"),
+        EntityType("transport_nodes"),
+        EntityType("virtual_nodes"),
+        EntityType("virtual_links"),
+    ]
+
+
+@pytest.fixture
+def default_attribute_types():
+    return [
+        AttributeType("id", DataType(int), description="Entity ID"),
+        AttributeType("geometry.x", DataType(float), unit="m"),
+        AttributeType("geometry.y", DataType(float), unit="m"),
+        AttributeType("geometry.linestring_2d", DataType(float, unit_shape=(2,), csr=True)),
+        AttributeType("topology.from_node_id", DataType(float)),
+        AttributeType("topology.to_node_id", DataType(float)),
+        AttributeType("transport.capacity", DataType(float)),
+        AttributeType("labels", DataType(int, (), True), enum_name="label"),
+    ]
+
+
+@pytest.fixture
+def default_model_types():
+    return [
+        ModelType(
+            "model_a",
+            jsonschema={
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                    "dataset": {"type": "string", "movici.type": "dataset"},
+                    "entity_group": {"type": "string", "movici.type": "entityGroup"},
+                    "attribute": {"type": "string", "movici.type": "attribute"},
+                },
+            },
+        ),
+        ModelType(
+            "model_b",
+            jsonschema={
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {"field": {"type": "string"}},
+            },
+        ),
+    ]
+
+
+@pytest.fixture
+def create_default_types(
+    default_dataset_types, default_entity_types, default_attribute_types, default_model_types
+):
+    created = False
+
+    async def _create(repository: SQLAlchemyRepository):
+        nonlocal created
+        if created:
+            return
+        for dataset_type in default_dataset_types:
+            await repository.dataset_types.create(dataset_type)
+        for entity_type in default_entity_types:
+            await repository.entity_types.create(entity_type)
+        for attribute_type in default_attribute_types:
+            await repository.attribute_types.create(attribute_type)
+        for model_type in default_model_types:
+            await repository.model_types.create(model_type)
+        created = True
+
+    return _create
+
+
+@pytest.fixture
+async def repository(session, create_default_types, a_workspace):
+    with patch.object(RawDataProcessor, "RAW_DATA_CHUNK_SIZE", 10):
+        options = await get_options(session)
+        repository = SQLAlchemyRepository(session, options)
+        await create_default_types(repository)
+        yield repository.for_workspace(a_workspace.id)
+
+
+@pytest.fixture
+async def get_model_config_validator(repository: SQLAlchemyRepository, a_workspace: Workspace):
+    async def _get_validator_for_workspace(workspace_id: UUID | None = None):
+        workspace_id = workspace_id or a_workspace.id
+        assert workspace_id is not None
+        return ModelConfigValidator.from_list_data(
+            attribute_types=await repository.attribute_types.list(),
+            entity_types=await repository.entity_types.list(),
+        )
+
+    return _get_validator_for_workspace
+
+
+@pytest.fixture
+async def model_config_validator(get_model_config_validator):
+    return await get_model_config_validator()
+
+
+@pytest.fixture
+def create_scenario(repository: SQLAlchemyRepository, a_workspace, get_model_config_validator):
+    async def _create_scenario(scenario: Scenario, workspace_id=None):
+        workspace_id = workspace_id or a_workspace.id
+        return await repository.for_workspace(workspace_id).scenarios.create(
+            scenario, await get_model_config_validator()
+        )
+
+    return _create_scenario
+
+
+@pytest.fixture
+async def create_update(
+    repository: SQLAlchemyRepository,
+    a_scenario,
+    a_dataset,
+    an_attribute_type,
+    an_entity_type,
+):
+    async def _create_update(timestamp, iteration, ids, array, scenario_id=None):
+        scenario_id = scenario_id or a_scenario.id
+        update = Update(
+            dataset=ScenarioDataset(a_dataset.name, a_dataset.dataset_type.name),
+            timestamp=timestamp,
+            iteration=iteration,
+            model_name=a_scenario.models[0]["name"],
+            model_type=a_scenario.models[0]["type"],
+            data={
+                an_entity_type.name: {
+                    "id": {"data": np.asarray(ids)},
+                    an_attribute_type.name: {"data": np.asarray(array)},
+                }
+            },
+        )
+
+        return await repository.for_scenario(scenario_id).updates.create(update)
+
+    return _create_update
+
+
+@pytest.fixture
+async def a_workspace(session: AsyncSession):
+    workspace = db_model.Workspace(name="default", display_name="Default Workspace")
+    session.add(workspace)
+    await session.flush()
+    return workspace.to_domain()
+
+
+@pytest.fixture
+async def a_dataset_type(repository: SQLAlchemyRepository):
+    return await repository.dataset_types.get_by_name("transport_network")
+
+
+@pytest.fixture
+async def an_entity_type(repository: SQLAlchemyRepository):
+    return await repository.entity_types.get_by_name("roads")
+
+
+@pytest.fixture
+async def an_attribute_type(repository: SQLAlchemyRepository) -> AttributeType:
+    attribute_id = await repository.attribute_types.create(
+        AttributeType(
+            name="some.attribute",
+            data_type=DataType(float),
+            unit="m/s",
+            description="a description",
+        )
+    )
+    return t.cast(AttributeType, await repository.attribute_types.get_by_id(attribute_id))
+
+
+@pytest.fixture
+async def a_csr_attribute_type(repository: SQLAlchemyRepository) -> AttributeType:
+    attribute_id = await repository.attribute_types.create(
+        AttributeType(
+            name="csr.attribute",
+            data_type=DataType(float, csr=True),
+            unit="m/s",
+            description="a description",
+        )
+    )
+    return t.cast(AttributeType, await repository.attribute_types.get_by_id(attribute_id))
+
+
+@pytest.fixture
+async def a_dataset(repository: SQLAlchemyRepository, a_dataset_type):
+    dataset_id = await repository.datasets.create(
+        Dataset(
+            name="a_transport_network",
+            display_name="A Transport Network",
+            dataset_type=a_dataset_type,
+        ),
+    )
+
+    return t.cast(Dataset, await repository.datasets.get_by_id(dataset_id))
+
+
+@pytest.fixture
+async def a_scenario(
+    default_model_types, a_dataset, repository: SQLAlchemyRepository, create_scenario
+):
+    scenario = Scenario(
+        name="a_scenario",
+        display_name="A Scenario",
+        description="Scenario for testing",
+        epsg_code=28992,
+        simulation_info={"some": "info"},
+        datasets=[
+            {
+                "name": a_dataset.name,
+                "type": a_dataset.dataset_type.name,
+            }
+        ],
+        models=[
+            {
+                "name": "model1",
+                "type": default_model_types[0].name,
+                "dataset": a_dataset.name,
+                "entity_group": "transport_nodes",
+                "attribute": "id",
+            },
+            {
+                "name": "model2",
+                "type": default_model_types[1].name,
+                "field": "value",
+            },
+        ],
+    )
+    scenario_id = await create_scenario(scenario)
+    return t.cast(Scenario, await repository.scenarios.for_id(scenario_id).get_by_id())

--- a/packages/data-core/tests/database/test_general.py
+++ b/packages/data-core/tests/database/test_general.py
@@ -23,7 +23,7 @@ async def test_initialize_db_for_single_scenario_sets_flags(session):
     assert options.mode == DatabaseMode.SINGLE_SCENARIO
     assert not options.STRICT_DATASET_TYPES
     assert not options.STRICT_ENTITY_TYPES
-    assert not options.STRICT_ATTRIBUTES
+    assert not options.STRICT_ATTRIBUTE_TYPES
     assert not options.STRICT_MODEL_TYPES
     assert not options.STRICT_SCENARIO_DATASETS
 
@@ -44,7 +44,7 @@ async def test_initialize_db_for_multiple_workspaces_sets_flags(session):
     assert options.mode == DatabaseMode.MULTIPLE_WORKSPACES
     assert options.STRICT_DATASET_TYPES
     assert options.STRICT_ENTITY_TYPES
-    assert options.STRICT_ATTRIBUTES
+    assert options.STRICT_ATTRIBUTE_TYPES
     assert options.STRICT_MODEL_TYPES
     assert options.STRICT_SCENARIO_DATASETS
 

--- a/packages/data-core/tests/database/test_general.py
+++ b/packages/data-core/tests/database/test_general.py
@@ -1,0 +1,56 @@
+import pytest
+
+from movici_data_core.database.general import get_options, get_version, initialize_database
+from movici_data_core.database.model import DatabaseMode
+
+
+@pytest.fixture
+def initialized_db(database_server):
+    """Override initialized_db fixture to be a noop"""
+    return database_server
+
+
+async def test_initialize_db_sets_default_version(session):
+    await initialize_database(session, mode=DatabaseMode.SINGLE_SCENARIO)
+    await session.flush()
+    assert (await get_version(session)) == "v1"
+
+
+async def test_initialize_db_for_single_scenario_sets_flags(session):
+    await initialize_database(session, mode=DatabaseMode.SINGLE_SCENARIO)
+    options = await get_options(session)
+
+    assert options.mode == DatabaseMode.SINGLE_SCENARIO
+    assert not options.STRICT_DATASET_TYPES
+    assert not options.STRICT_ENTITY_TYPES
+    assert not options.STRICT_ATTRIBUTES
+    assert not options.STRICT_MODEL_TYPES
+    assert not options.STRICT_SCENARIO_DATASETS
+
+
+async def test_initialize_db_for_single_scenario_creates_default_workspace(session):
+    await initialize_database(session, mode=DatabaseMode.SINGLE_SCENARIO)
+    options = await get_options(session)
+
+    assert options.default_workspace is not None
+    assert options.default_workspace.name == "__default__"
+    assert options.default_workspace.display_name == "__default__"
+
+
+async def test_initialize_db_for_multiple_workspaces_sets_flags(session):
+    await initialize_database(session, mode=DatabaseMode.MULTIPLE_WORKSPACES)
+    options = await get_options(session)
+
+    assert options.mode == DatabaseMode.MULTIPLE_WORKSPACES
+    assert options.STRICT_DATASET_TYPES
+    assert options.STRICT_ENTITY_TYPES
+    assert options.STRICT_ATTRIBUTES
+    assert options.STRICT_MODEL_TYPES
+    assert options.STRICT_SCENARIO_DATASETS
+
+
+async def test_initialize_db_for_multiple_workspaces_does_not_create_default_workspace(session):
+    await initialize_database(session, mode=DatabaseMode.MULTIPLE_WORKSPACES)
+    options = await get_options(session)
+
+    assert options.default_workspace is None

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -328,7 +328,7 @@ class TestAttributeTypeRepository:
     async def test_returns_existing_attribute_type_when_compatible(
         self, repository: SQLAlchemyRepository, an_attribute_type
     ):
-        repository.options.STRICT_ATTRIBUTES = True
+        repository.options.STRICT_ATTRIBUTE_TYPES = True
         found = await repository.attribute_types.ensure_attribute_type(
             AttributeType("some.attribute", data_type=DataType(float))
         )
@@ -338,7 +338,7 @@ class TestAttributeTypeRepository:
     async def test_raises_on_non_existing_attribute_type_when_strict(
         self, repository: SQLAlchemyRepository
     ):
-        repository.options.STRICT_ATTRIBUTES = True
+        repository.options.STRICT_ATTRIBUTE_TYPES = True
 
         with pytest.raises(ResourceDoesNotExist):
             await repository.attribute_types.ensure_attribute_type(
@@ -348,7 +348,7 @@ class TestAttributeTypeRepository:
     async def test_automatically_creates_attribute_type_when_not_strict(
         self, repository: SQLAlchemyRepository
     ):
-        repository.options.STRICT_ATTRIBUTES = False
+        repository.options.STRICT_ATTRIBUTE_TYPES = False
 
         attribute_type = await repository.attribute_types.ensure_attribute_type(
             AttributeType("some.attribute", data_type=DataType(float))
@@ -361,7 +361,7 @@ class TestAttributeTypeRepository:
     async def test_raises_on_incompatible_existing_attribute_type(
         self, repository: SQLAlchemyRepository, an_attribute_type
     ):
-        repository.options.STRICT_ATTRIBUTES = False
+        repository.options.STRICT_ATTRIBUTE_TYPES = False
 
         with pytest.raises(InvalidResource):
             await repository.attribute_types.ensure_attribute_type(

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -612,7 +612,7 @@ class TestDatasetDataRepository:
         result = b""
         n_chunks = 0
 
-        _, gen = await repository.dataset_data.stream_binary_data(a_dataset.id)
+        gen = await repository.dataset_data.stream_binary_data(a_dataset.id)
         async for chunk in gen:
             result += chunk
             n_chunks += 1
@@ -940,7 +940,7 @@ class TestScenarioRepository:
         validator = await get_model_config_validator()
 
         scenario_id = await repository.scenarios.create(new_scenario, validator)
-        result = await repository.scenarios.for_id(scenario_id).get_by_id()
+        result = await repository.scenarios.for_id(scenario_id).get()
         assert result is not None
 
         assert result.id is not None
@@ -992,7 +992,7 @@ class TestScenarioRepository:
         a_scenario.models = list(reversed(a_scenario.models))
         await repository.scenarios.for_id(a_scenario.id).update(a_scenario, validator)
 
-        result = await repository.scenarios.for_id(a_scenario.id).get_by_id()
+        result = await repository.scenarios.for_id(a_scenario.id).get()
 
         assert result is not None
         assert result.name == a_scenario.name

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -1,0 +1,1112 @@
+import dataclasses
+import uuid
+from io import BytesIO
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import joinedload
+
+from movici_data_core.database import model as db
+from movici_data_core.database.repository import DatasetDataRepository, SQLAlchemyRepository
+from movici_data_core.domain_model import (
+    AttributeSummary,
+    AttributeType,
+    BoundingBox,
+    Dataset,
+    DatasetFormat,
+    DatasetSummary,
+    DatasetType,
+    EntityGroupSummary,
+    EntityType,
+    ModelType,
+    Scenario,
+    ScenarioDataset,
+    Update,
+    Workspace,
+)
+from movici_data_core.exceptions import (
+    InvalidAction,
+    InvalidResource,
+    ResourceAlreadyExists,
+    ResourceDoesNotExist,
+)
+from movici_simulation_core.core import DataType
+from movici_simulation_core.core.schema import DEFAULT_ROWPTR_KEY
+from movici_simulation_core.testing import (
+    assert_dataset_dicts_equal,
+    dataset_data_to_numpy,
+    dataset_dicts_equal,
+)
+
+
+class TestWorkspaceRepository:
+    @pytest.fixture
+    async def filled_workspace(
+        self, repository: SQLAlchemyRepository, a_workspace, a_dataset, a_scenario
+    ):
+        await repository.datasets.create(dataclasses.replace(a_dataset, name="another_dataset"))
+        return await repository.workspaces.get_by_id(a_workspace.id)
+
+    async def test_list_workspaces_with_counts(
+        self, repository: SQLAlchemyRepository, filled_workspace
+    ):
+        result = await repository.workspaces.list()
+        assert len(result) == 1
+        assert result[0].dataset_count == 2
+        assert result[0].scenario_count == 1
+
+    async def filled_workspace_has_counts(self, filled_workspace):
+        assert filled_workspace.dataset_count == 2
+        assert filled_workspace.scenario_count == 1
+
+    async def test_get_workspace_by_id(self, repository: SQLAlchemyRepository, filled_workspace):
+        assert filled_workspace.id is not None
+        found = await repository.workspaces.get_by_id(filled_workspace.id)
+        assert filled_workspace == found
+
+    async def test_get_workspace_by_name(self, repository: SQLAlchemyRepository, filled_workspace):
+        found = await repository.workspaces.get_by_name(filled_workspace.name)
+        assert filled_workspace == found
+
+    async def test_get_non_existing_workspace_by_name(self, repository: SQLAlchemyRepository):
+        assert (await repository.workspaces.get_by_name("invalid")) is None
+
+    async def test_get_non_existing_workspace_by_id(self, repository: SQLAlchemyRepository):
+        assert (await repository.workspaces.get_by_id(uuid.uuid4())) is None
+
+    async def test_created_workspace_gets_a_uuid(self, repository: SQLAlchemyRepository):
+        workspace_id = await repository.workspaces.create(
+            Workspace(name="some_workspace", display_name="Some Workspace")
+        )
+        assert int(workspace_id) > 0
+
+    async def test_create_and_delete_a_workspace(self, repository: SQLAlchemyRepository):
+        existing = len(await repository.workspaces.list())
+        workspace_id = await repository.workspaces.create(
+            Workspace(name="some_workspace", display_name="Some Workspace")
+        )
+        assert len(await repository.workspaces.list()) == existing + 1
+
+        await repository.workspaces.delete(workspace_id)
+
+        assert len(await repository.workspaces.list()) == existing
+
+    async def test_workspace_exists(self, repository: SQLAlchemyRepository):
+        assert not await repository.workspaces.exists("some_workspace")
+        await repository.workspaces.create(
+            Workspace(name="some_workspace", display_name="Some Workspace")
+        )
+        assert await repository.workspaces.exists("some_workspace")
+
+    async def test_update_workspace(
+        self, repository: SQLAlchemyRepository, a_workspace: Workspace
+    ):
+        assert a_workspace.id is not None
+        assert a_workspace.name != "new_name"
+        assert a_workspace.display_name != "New Name"
+
+        await repository.workspaces.update(
+            a_workspace.id,
+            dataclasses.replace(a_workspace, name="new_name", display_name="New Name"),
+        )
+        updated = await repository.workspaces.get_by_id(a_workspace.id)
+        assert updated is not None
+        assert updated.name == "new_name"
+        assert updated.display_name == "New Name"
+
+
+class TestDatasetTypeRepository:
+    async def test_create_and_delete_a_dataset_type(self, repository: SQLAlchemyRepository):
+        existing = len(await repository.dataset_types.list())
+        dataset_type_id = await repository.dataset_types.create(
+            DatasetType(name="a_dataset_type", format=DatasetFormat.ENTITY_BASED)
+        )
+
+        assert dataset_type_id is not None
+        assert len(await repository.dataset_types.list()) == existing + 1
+
+        await repository.dataset_types.delete(dataset_type_id)
+
+        assert len(await repository.dataset_types.list()) == existing
+
+    async def test_update_dataset_type(self, repository: SQLAlchemyRepository):
+
+        dataset_type = DatasetType(name="a_dataset_type", format=DatasetFormat.ENTITY_BASED)
+
+        dataset_type_id = await repository.dataset_types.create(dataset_type)
+
+        await repository.dataset_types.update(
+            dataset_type_id, dataclasses.replace(dataset_type, name="new_name")
+        )
+        updated = await repository.dataset_types.get_by_id(dataset_type_id)
+        assert updated is not None
+        assert updated.name == "new_name"
+
+    async def test_cannot_change_format(self, repository: SQLAlchemyRepository):
+        dataset_type = DatasetType(name="a_dataset_type", format=DatasetFormat.ENTITY_BASED)
+        dataset_type_id = await repository.dataset_types.create(dataset_type)
+
+        dataset_type.format = DatasetFormat.UNSTRUCTURED
+        with pytest.raises(InvalidAction):
+            await repository.dataset_types.update(
+                dataset_type_id, dataclasses.replace(dataset_type, name="new_name")
+            )
+
+    async def test_returns_existing_dataset_type_when_format_unknown(
+        self, repository: SQLAlchemyRepository, a_dataset_type
+    ):
+        repository.options.STRICT_DATASET_TYPES = True
+        found = await repository.dataset_types.ensure_dataset_type(
+            DatasetType(name="transport_network", format=DatasetFormat.UNKNOWN)
+        )
+        assert found == a_dataset_type
+
+    async def test_returns_existing_dataset_type_when_compatible(
+        self, repository: SQLAlchemyRepository, a_dataset_type
+    ):
+        repository.options.STRICT_DATASET_TYPES = True
+        found = await repository.dataset_types.ensure_dataset_type(
+            DatasetType(name="transport_network", format=DatasetFormat.ENTITY_BASED)
+        )
+        assert found == a_dataset_type
+
+    async def test_raises_on_non_existing_dataset_type_when_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_DATASET_TYPES = True
+
+        with pytest.raises(ResourceDoesNotExist):
+            await repository.dataset_types.ensure_dataset_type(
+                DatasetType(name="non-existing", format=DatasetFormat.ENTITY_BASED)
+            )
+
+    async def test_automatically_creates_dataset_type_when_not_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_DATASET_TYPES = False
+
+        dataset_type = await repository.dataset_types.ensure_dataset_type(
+            DatasetType(name="transport_network", format=DatasetFormat.ENTITY_BASED)
+        )
+
+        assert dataset_type is not None
+        assert dataset_type.name == "transport_network"
+        assert dataset_type.id is not None
+
+    async def test_raises_on_incompatible_existing_dataset_type(
+        self, repository: SQLAlchemyRepository, a_dataset_type
+    ):
+        repository.options.STRICT_DATASET_TYPES = False
+
+        with pytest.raises(InvalidResource):
+            await repository.dataset_types.ensure_dataset_type(
+                DatasetType(name="transport_network", format=DatasetFormat.BINARY)
+            )
+
+
+class TestEntityTypeRepository:
+    async def test_create_and_delete_an_entity_type(self, repository: SQLAlchemyRepository):
+        existing = len(await repository.entity_types.list())
+        entity_type_id = await repository.entity_types.create(EntityType(name="some_entity_type"))
+        assert len(await repository.entity_types.list()) == existing + 1
+
+        await repository.entity_types.delete(entity_type_id)
+
+        assert len(await repository.entity_types.list()) == existing
+
+    async def test_update_entity_type(
+        self, repository: SQLAlchemyRepository, an_entity_type: EntityType
+    ):
+        assert an_entity_type.id is not None
+
+        await repository.entity_types.update(
+            an_entity_type.id, dataclasses.replace(an_entity_type, name="new_name")
+        )
+        updated = await repository.entity_types.get_by_id(an_entity_type.id)
+        assert updated is not None
+        assert updated.name == "new_name"
+
+    async def test_returns_existing_entity_type_when_compatible(
+        self, repository: SQLAlchemyRepository, an_entity_type
+    ):
+        repository.options.STRICT_ENTITY_TYPES = True
+        found = await repository.entity_types.ensure_entity_type(EntityType(an_entity_type.name))
+        assert found is not None
+        assert found.id == an_entity_type.id
+
+    async def test_raises_on_non_existing_entity_type_when_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_ENTITY_TYPES = True
+
+        with pytest.raises(ResourceDoesNotExist):
+            await repository.entity_types.ensure_entity_type(EntityType("new_type"))
+
+    async def test_automatically_creates_entity_type_when_not_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_ENTITY_TYPES = False
+
+        entity_type = await repository.entity_types.ensure_entity_type(EntityType("new_type"))
+
+        assert entity_type is not None
+        assert entity_type.name == "new_type"
+        assert entity_type.id is not None
+
+
+class TestAttributeTypeRepository:
+    async def test_created_attribute_type_has_data_type(self, repository: SQLAlchemyRepository):
+        data_type = DataType(int, (2,), csr=True)
+        await repository.attribute_types.create(
+            AttributeType("attribute_type", data_type=data_type)
+        )
+        attribute_type = await repository.attribute_types.get_by_name("attribute_type")
+        assert attribute_type is not None
+        assert attribute_type.data_type == data_type
+
+    async def test_create_attribute_type_with_enum(self, repository: SQLAlchemyRepository):
+        data_type = DataType(float)
+        await repository.attribute_types.create(
+            AttributeType("attribute_type", data_type=data_type, enum_name="something")
+        )
+        attribute_type = await repository.attribute_types.get_by_name("attribute_type")
+        assert attribute_type is not None
+        assert attribute_type.enum_name == "something"
+
+    async def test_create_and_delete_an_attribute_type(self, repository: SQLAlchemyRepository):
+        existing = len(await repository.attribute_types.list())
+        attribute_type_id = await repository.attribute_types.create(
+            AttributeType(name="some_attribute_type", data_type=DataType(float))
+        )
+        assert len(await repository.attribute_types.list()) == existing + 1
+
+        await repository.attribute_types.delete(attribute_type_id)
+
+        assert len(await repository.attribute_types.list()) == existing
+
+    async def test_update_attribute_type(
+        self, repository: SQLAlchemyRepository, an_attribute_type: AttributeType
+    ):
+        assert an_attribute_type.id is not None
+
+        await repository.attribute_types.update(
+            an_attribute_type.id, dataclasses.replace(an_attribute_type, name="new_name")
+        )
+        updated = await repository.attribute_types.get_by_id(an_attribute_type.id)
+        assert updated is not None
+        assert updated.name == "new_name"
+
+    async def test_cannot_update_data_type_if_in_use(
+        self,
+        repository: SQLAlchemyRepository,
+        an_attribute_type: AttributeType,
+        a_dataset,
+        an_entity_type,
+    ):
+        assert an_attribute_type.id is not None
+
+        await repository.dataset_data.create(
+            a_dataset.id,
+            {
+                an_entity_type.name: {
+                    an_attribute_type.name: {
+                        "data": np.array([1.0, 2.0]),
+                    },
+                }
+            },
+            format=DatasetFormat.ENTITY_BASED,
+        )
+        with pytest.raises(InvalidAction):
+            await repository.attribute_types.update(
+                an_attribute_type.id,
+                dataclasses.replace(an_attribute_type, data_type=DataType(int)),
+            )
+
+    async def test_returns_existing_attribute_type_when_compatible(
+        self, repository: SQLAlchemyRepository, an_attribute_type
+    ):
+        repository.options.STRICT_ATTRIBUTES = True
+        found = await repository.attribute_types.ensure_attribute_type(
+            AttributeType("some.attribute", data_type=DataType(float))
+        )
+        assert found is not None
+        assert found.id == an_attribute_type.id
+
+    async def test_raises_on_non_existing_attribute_type_when_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_ATTRIBUTES = True
+
+        with pytest.raises(ResourceDoesNotExist):
+            await repository.attribute_types.ensure_attribute_type(
+                AttributeType("some.attribute", data_type=DataType(float))
+            )
+
+    async def test_automatically_creates_attribute_type_when_not_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_ATTRIBUTES = False
+
+        attribute_type = await repository.attribute_types.ensure_attribute_type(
+            AttributeType("some.attribute", data_type=DataType(float))
+        )
+
+        assert attribute_type is not None
+        assert attribute_type.name == "some.attribute"
+        assert attribute_type.id is not None
+
+    async def test_raises_on_incompatible_existing_attribute_type(
+        self, repository: SQLAlchemyRepository, an_attribute_type
+    ):
+        repository.options.STRICT_ATTRIBUTES = False
+
+        with pytest.raises(InvalidResource):
+            await repository.attribute_types.ensure_attribute_type(
+                AttributeType("some.attribute", data_type=DataType(int))
+            )
+
+
+class TestModelTypeRepository:
+    @pytest.fixture
+    async def a_model_type(self, repository: SQLAlchemyRepository):
+        model_type_id = await repository.model_types.create(
+            ModelType(name="some_model", jsonschema={"some": "schema"})
+        )
+        return await repository.model_types.get_by_id(model_type_id)
+
+    async def test_created_model_type_has_schema(self, a_model_type):
+        assert a_model_type.jsonschema == {"some": "schema"}
+
+    async def test_update_model_type(
+        self, a_model_type: ModelType, repository: SQLAlchemyRepository
+    ):
+        assert a_model_type.id is not None
+
+        await repository.model_types.update(
+            a_model_type.id, ModelType("another_name", {"some": "othershema"})
+        )
+
+        updated = await repository.model_types.get_by_name("another_name")
+        assert updated is not None
+        assert updated.jsonschema == {"some": "othershema"}
+
+    async def test_returns_existing_model_type(
+        self, repository: SQLAlchemyRepository, a_model_type
+    ):
+        repository.options.STRICT_MODEL_TYPES = True
+        found = await repository.model_types.ensure_model_types(["some_model"])
+        assert found == [a_model_type]
+
+    async def test_raises_on_non_existing_model_type_when_strict(
+        self, repository: SQLAlchemyRepository
+    ):
+        repository.options.STRICT_MODEL_TYPES = True
+
+        with pytest.raises(ResourceDoesNotExist):
+            await repository.model_types.ensure_model_types(["non-existing"])
+
+    async def test_automatically_creates_model_type_with_passall_schema_when_not_strict(
+        self, repository: SQLAlchemyRepository, a_model_type
+    ):
+        repository.options.STRICT_MODEL_TYPES = False
+
+        created, existing = await repository.model_types.ensure_model_types(
+            ["new", a_model_type.name]
+        )
+        assert existing == a_model_type
+        assert created is not None
+        assert created.name == "new"
+        assert created.jsonschema == {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "/new/1.0.0",
+            "type": "object",
+            "additionalProperties": True,
+        }
+
+
+class TestDatasetRepository:
+    async def test_get_dataset_with_workspace_and_dataset_type(
+        self, repository: SQLAlchemyRepository, a_dataset
+    ):
+        dataset = await repository.datasets.get_by_id(a_dataset.id)
+        assert dataset is not None
+        assert isinstance(dataset.workspace, Workspace)
+        assert isinstance(dataset.dataset_type, DatasetType)
+
+    async def test_create_dataset(self, repository: SQLAlchemyRepository, a_dataset_type):
+        dataset_id = await repository.datasets.create(
+            Dataset("another_dataset", "Another Dataset", dataset_type=a_dataset_type)
+        )
+        assert int(dataset_id) > 0
+
+    async def test_dataset_exists(self, repository: SQLAlchemyRepository, a_dataset_type):
+        assert not await repository.datasets.exists("another_dataset")
+
+        await repository.datasets.create(
+            Dataset("another_dataset", "Another Dataset", dataset_type=a_dataset_type)
+        )
+
+        assert await repository.datasets.exists("another_dataset")
+
+    async def test_raises_on_existing_dataset(self, repository: SQLAlchemyRepository, a_dataset):
+        with pytest.raises(ResourceAlreadyExists):
+            await repository.datasets.create(a_dataset)
+
+    async def test_update_dataset(self, repository: SQLAlchemyRepository, a_dataset):
+        await repository.datasets.update(
+            a_dataset.id, dataclasses.replace(a_dataset, name="new_name")
+        )
+        updated = await repository.datasets.get_by_id(a_dataset.id)
+        assert updated is not None
+        assert updated.name == "new_name"
+
+    async def test_raises_on_invalid_dataset_type_when_strict(
+        self, repository: SQLAlchemyRepository, a_workspace, a_dataset_type
+    ):
+        repository.options.STRICT_DATASET_TYPES = True
+
+        with pytest.raises(InvalidResource):
+            await repository.for_workspace(a_workspace.id).datasets.create(
+                Dataset(
+                    "some_dataset",
+                    "some dataset",
+                    dataset_type=DatasetType(a_dataset_type.name, format=DatasetFormat.BINARY),
+                ),
+            )
+
+    async def test_delete_dataset_deletes_data(self, repository: SQLAlchemyRepository, a_dataset):
+        with patch.object(DatasetDataRepository, "delete") as mock:
+            await repository.datasets.delete(a_dataset.id)
+            mock.assert_awaited_once_with(a_dataset.id)
+
+    async def test_returns_existing_datasets(self, repository: SQLAlchemyRepository, a_dataset):
+        repository.options.STRICT_SCENARIO_DATASETS = True
+        another_dataset_id = await repository.datasets.create(
+            Dataset(
+                "another_dataset",
+                "another_dataset",
+                DatasetType("tabular", format=DatasetFormat.UNSTRUCTURED),
+            ),
+        )
+        another_dataset = await repository.datasets.get_by_id(another_dataset_id)
+        assert another_dataset is not None
+
+        found = await repository.datasets.ensure_scenario_datasets(
+            [
+                ScenarioDataset(a_dataset.name, a_dataset.dataset_type.name),
+                ScenarioDataset(another_dataset.name, another_dataset.dataset_type.name),
+            ],
+        )
+        assert [ds.id for ds in found] == [a_dataset.id, another_dataset.id]
+
+    async def test_raises_on_missing_dataset_when_strict(self, repository: SQLAlchemyRepository):
+        repository.options.STRICT_SCENARIO_DATASETS = True
+
+        with pytest.raises(ResourceDoesNotExist):
+            await repository.datasets.ensure_scenario_datasets(
+                [ScenarioDataset("non-existing", type="transport_network")],
+            )
+
+    async def test_automatically_creates_dataset_stubs_when_not_strict(
+        self, repository: SQLAlchemyRepository, a_dataset
+    ):
+        repository.options.STRICT_SCENARIO_DATASETS = False
+
+        scenario_datasets = await repository.datasets.ensure_scenario_datasets(
+            [
+                ScenarioDataset("new", "transport_network"),
+                ScenarioDataset(a_dataset.name, a_dataset.dataset_type.name),
+                ScenarioDataset("new_tapefile", "tabular"),
+            ],
+        )
+        assert [ds.name for ds in scenario_datasets] == ["new", a_dataset.name, "new_tapefile"]
+        assert [ds.type for ds in scenario_datasets] == [
+            "transport_network",
+            a_dataset.dataset_type.name,
+            "tabular",
+        ]
+        assert None not in [ds.id for ds in scenario_datasets]
+
+    async def test_create_new_dataset_type_when_required(self, repository: SQLAlchemyRepository):
+        repository.options.STRICT_SCENARIO_DATASETS = False
+        repository.options.STRICT_DATASET_TYPES = False
+
+        await repository.datasets.ensure_scenario_datasets([ScenarioDataset("new", "new_type")])
+        created = await repository.dataset_types.get_by_name("new_type")
+        assert created is not None
+        assert created == DatasetType("new_type", format=DatasetFormat.ENTITY_BASED)
+
+    async def test_raises_on_existing_scenario_dataset_with_incorrect_type(
+        self, repository: SQLAlchemyRepository, a_dataset
+    ):
+
+        repository.options.STRICT_SCENARIO_DATASETS = False
+
+        with pytest.raises(InvalidResource):
+            await repository.datasets.ensure_scenario_datasets(
+                [ScenarioDataset(name=a_dataset.name, type="tabular")]
+            )
+
+    async def test_update_with_data(self, repository: SQLAlchemyRepository, a_dataset):
+        await repository.datasets.update_with_data(
+            a_dataset.id,
+            dataclasses.replace(
+                a_dataset,
+                general={"enum": {"label": ["a", "b"]}},
+                epsg_code=1234,
+                bounding_box=BoundingBox(1.0, 2.0, 3.0, 4.0),
+                data=dataset_data_to_numpy(
+                    {
+                        "transport_nodes": {
+                            "id": [1, 2, 3],
+                            "labels": {"data": [0, 0, 1, 1], "rowptr": [0, 1, 3, 4]},
+                        },
+                    }
+                ),
+            ),
+        )
+        result = await repository.datasets.get_by_id(a_dataset.id)
+        assert result is not None
+        assert result.epsg_code == 1234
+        assert result.bounding_box == BoundingBox(1.0, 2.0, 3.0, 4.0)
+        assert result.general == {"enum": {"label": ["a", "b"]}}
+        data = await repository.dataset_data.get_entity_data(a_dataset.id)
+        assert dataset_dicts_equal(
+            data,
+            {
+                "transport_nodes": {
+                    "id": {"data": np.array([1, 2, 3])},
+                    "labels": {
+                        "data": np.array([0, 0, 1, 1]),
+                        DEFAULT_ROWPTR_KEY: [0, 1, 3, 4],
+                    },
+                }
+            },
+        )
+
+
+class TestDatasetDataRepository:
+    @pytest.mark.parametrize("method", ["path", "bytes", "bytesio"])
+    async def test_store_and_retrieve_raw_data_bytes(
+        self, repository: SQLAlchemyRepository, a_dataset, method, tmp_path
+    ):
+        assert not await repository.dataset_data.exists_for(a_dataset.id)
+        raw_bytes = b"somethingbinarydata"
+        data = None
+        if method == "path":
+            data = tmp_path / "data.bin"
+            data.write_bytes(raw_bytes)
+        elif method == "bytes":
+            data = raw_bytes
+        elif method == "bytesio":
+            data = BytesIO(raw_bytes)
+        assert data is not None
+
+        await repository.dataset_data.create(
+            a_dataset.id, data, format=DatasetFormat.BINARY, chunk_size=2
+        )
+        assert await repository.dataset_data.exists_for(a_dataset.id)
+        result = b""
+        n_chunks = 0
+
+        _, gen = await repository.dataset_data.stream_binary_data(a_dataset.id)
+        async for chunk in gen:
+            result += chunk
+            n_chunks += 1
+        assert n_chunks == len(raw_bytes) // 2 + 1
+        assert result == raw_bytes
+
+    async def test_store_and_retrieve_unstructured_data(
+        self, repository: SQLAlchemyRepository, a_dataset
+    ):
+        assert not await repository.dataset_data.exists_for(a_dataset.id)
+        data = {"some": "data"}
+        await repository.dataset_data.create(a_dataset.id, data, format=DatasetFormat.UNSTRUCTURED)
+        assert await repository.dataset_data.exists_for(a_dataset.id)
+        result = await repository.dataset_data.get_unstructured_data(a_dataset.id)
+        assert result == data
+
+    async def test_store_and_retrieve_entity_data(
+        self,
+        repository: SQLAlchemyRepository,
+        a_dataset,
+        an_entity_type,
+        an_attribute_type,
+        a_csr_attribute_type,
+    ):
+        assert not await repository.dataset_data.exists_for(a_dataset.id)
+        data = {
+            an_entity_type.name: {
+                an_attribute_type.name: {
+                    "data": np.array([1.0, 2.0]),
+                },
+                a_csr_attribute_type.name: {
+                    "data": np.array([1.0, 2.0]),
+                    "indptr": np.array([0, 2, 2]),
+                },
+            }
+        }
+        await repository.dataset_data.create(a_dataset.id, data, format=DatasetFormat.ENTITY_BASED)
+        assert await repository.dataset_data.exists_for(a_dataset.id)
+        result = await repository.dataset_data.get_entity_data(a_dataset.id)
+        assert_dataset_dicts_equal(data, result)
+
+    async def test_store_multiple_entity_data_retrieve_one(
+        self,
+        repository: SQLAlchemyRepository,
+        a_dataset,
+        an_entity_type,
+        an_attribute_type,
+        a_csr_attribute_type,
+    ):
+        another_dataset = Dataset("another_dataset", "Another Dataset", a_dataset.dataset_type)
+
+        another_dataset_id = await repository.datasets.create(another_dataset)
+        data = {
+            an_entity_type.name: {
+                an_attribute_type.name: {
+                    "data": np.array([1.0, 2.0]),
+                }
+            }
+        }
+        await repository.dataset_data.create(
+            another_dataset_id,
+            {
+                an_entity_type.name: {
+                    a_csr_attribute_type.name: {
+                        "data": np.array([1.0, 2.0]),
+                        "indptr": np.array([0, 2, 2]),
+                    },
+                }
+            },
+            format=DatasetFormat.ENTITY_BASED,
+        )
+        await repository.dataset_data.create(a_dataset.id, data, format=DatasetFormat.ENTITY_BASED)
+        result = await repository.dataset_data.get_entity_data(a_dataset.id)
+        assert_dataset_dicts_equal(data, result)
+
+    @pytest.mark.parametrize(
+        "datatype, values, min_val, max_val",
+        [
+            (bool, [False, False], False, True),
+            (int, [2, -1], -1, 2),
+            (float, [0.0, np.nan], 0.0, 0.0),
+            (float, [np.nan], None, None),
+            (float, [], None, None),
+            (str, ["a", "b"], None, None),
+        ],
+    )
+    async def test_stores_min_max(
+        self,
+        repository: SQLAlchemyRepository,
+        datatype,
+        values,
+        min_val,
+        max_val,
+        a_dataset,
+        an_entity_type,
+    ):
+        await repository.attribute_types.create(AttributeType("some.attr", DataType(datatype)))
+
+        await repository.dataset_data.create(
+            a_dataset.id,
+            {an_entity_type.name: {"some.attr": {"data": np.asarray(values)}}},
+            format=DatasetFormat.ENTITY_BASED,
+        )
+        attribute = await repository.session.scalar(
+            select(db.Attribute)
+            .options(joinedload(db.Attribute.data))
+            .join(db.DatasetAttribute)
+            .where(db.DatasetAttribute.dataset_id == a_dataset.id)
+            .limit(1)
+        )
+        assert attribute is not None
+        assert attribute.data.min_val == min_val
+        assert attribute.data.max_val == max_val
+
+    @pytest.mark.parametrize(
+        "unit_shape, values, length",
+        [
+            ((), [1, 2, 3], 3),
+            ((2,), [[1, 2], [2, 3], [3, 4], [4, 5]], 4),
+        ],
+    )
+    async def test_stores_attribute_length(
+        self,
+        repository: SQLAlchemyRepository,
+        a_dataset,
+        an_entity_type,
+        unit_shape,
+        values,
+        length,
+    ):
+        await repository.attribute_types.create(
+            AttributeType("some.attr", DataType(int, unit_shape=unit_shape))
+        )
+
+        await repository.dataset_data.create(
+            a_dataset.id,
+            {an_entity_type.name: {"some.attr": {"data": np.asarray(values)}}},
+            format=DatasetFormat.ENTITY_BASED,
+        )
+
+        attribute = await repository.session.scalar(
+            select(db.Attribute)
+            .join(db.DatasetAttribute)
+            .where(db.DatasetAttribute.dataset_id == a_dataset.id)
+            .limit(1)
+        )
+        assert attribute is not None
+        assert attribute.length == length
+
+    async def test_deletes_entity_data(
+        self, repository: SQLAlchemyRepository, a_dataset, an_entity_type, an_attribute_type
+    ):
+        data = {
+            an_entity_type.name: {
+                an_attribute_type.name: {
+                    "data": np.array([1.0, 2.0]),
+                }
+            }
+        }
+        await repository.dataset_data.create(a_dataset.id, data, format=DatasetFormat.ENTITY_BASED)
+        attribute_count = await repository.session.scalar(select(func.count(db.Attribute.id)))
+        assert attribute_count != 0
+
+        await repository.dataset_data.delete(a_dataset.id)
+
+        attribute_count = await repository.session.scalar(select(func.count(db.Attribute.id)))
+        assert attribute_count == 0
+
+    async def test_deletes_raw_data(self, repository: SQLAlchemyRepository, a_dataset):
+        raw_bytes = b"somethingbinarydata"
+
+        await repository.dataset_data.create(a_dataset.id, raw_bytes, format=DatasetFormat.BINARY)
+        data_count = await repository.session.scalar(select(func.count(db.RawData.id)))
+        assert data_count != 0
+
+        await repository.dataset_data.delete(a_dataset.id)
+
+        data_count = await repository.session.scalar(select(func.count(db.RawData.id)))
+        assert data_count == 0
+
+    async def test_get_dataset_summary(self, repository: SQLAlchemyRepository, a_dataset):
+        await repository.datasets.update_with_data(
+            a_dataset.id,
+            dataclasses.replace(
+                a_dataset,
+                general={"enum": {"label": ["a", "b"]}},
+                epsg_code=1234,
+                bounding_box=BoundingBox(1.0, 2.0, 3.0, 4.0),
+                data=dataset_data_to_numpy(
+                    {
+                        "transport_nodes": {
+                            "id": [1, 2, 3],
+                            "labels": {"data": [0, 0, 1, 1], "rowptr": [0, 1, 3, 4]},
+                            "geometry.x": [4.0, 5.0, 6.0],
+                            "geometry.y": [4.0, 5.0, 6.0],
+                        },
+                        "roads": {
+                            "id": [4, 5, 6, 7],
+                            "transport.capacity": [12.0, 13.0, 14.0, 15.0],
+                        },
+                    }
+                ),
+            ),
+        )
+
+        summary = await repository.datasets.get_summary(a_dataset.id)
+        assert summary == DatasetSummary(
+            general={"enum": {"label": ["a", "b"]}},
+            epsg_code=1234,
+            bounding_box=BoundingBox(1.0, 2.0, 3.0, 4.0),
+            count=7,
+            entity_groups=[
+                EntityGroupSummary(
+                    name="roads",
+                    count=4,
+                    attributes=[
+                        AttributeSummary(
+                            name="id",
+                            data_type=DataType(int),
+                            description="Entity ID",
+                            enum_name=None,
+                            unit="",
+                            min_val=4,
+                            max_val=7,
+                        ),
+                        AttributeSummary(
+                            name="transport.capacity",
+                            data_type=DataType(float),
+                            description="",
+                            enum_name=None,
+                            unit="",
+                            min_val=12,
+                            max_val=15,
+                        ),
+                    ],
+                ),
+                EntityGroupSummary(
+                    name="transport_nodes",
+                    count=3,
+                    attributes=[
+                        AttributeSummary(
+                            name="geometry.x",
+                            data_type=DataType(float),
+                            description="",
+                            enum_name=None,
+                            unit="m",
+                            min_val=4,
+                            max_val=6,
+                        ),
+                        AttributeSummary(
+                            name="geometry.y",
+                            data_type=DataType(float),
+                            description="",
+                            enum_name=None,
+                            unit="m",
+                            min_val=4,
+                            max_val=6,
+                        ),
+                        AttributeSummary(
+                            name="id",
+                            data_type=DataType(int),
+                            description="Entity ID",
+                            enum_name=None,
+                            unit="",
+                            min_val=1,
+                            max_val=3,
+                        ),
+                        AttributeSummary(
+                            name="labels",
+                            data_type=DataType(int, csr=True),
+                            description="",
+                            enum_name="label",
+                            unit="",
+                            min_val=0,
+                            max_val=1,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+
+class TestScenarioRepository:
+    @pytest.fixture
+    def new_scenario(self, a_dataset, default_model_types):
+        return Scenario(
+            name="some_scenario",
+            workspace=a_dataset.workspace,
+            display_name="Some Scenario",
+            description="Scenario for testing",
+            epsg_code=28992,
+            simulation_info={"some": "info"},
+            datasets=[
+                {
+                    "name": a_dataset.name,
+                    "type": a_dataset.dataset_type.name,
+                }
+            ],
+            models=[
+                {
+                    "name": "model1",
+                    "type": default_model_types[0].name,
+                    "dataset": a_dataset.name,
+                    "entity_group": "transport_nodes",
+                    "attribute": "id",
+                },
+                {
+                    "name": "model2",
+                    "type": default_model_types[1].name,
+                    "field": "value",
+                },
+            ],
+        )
+
+    async def test_list_scenarios(self, repository: SQLAlchemyRepository, a_scenario):
+        return len(await repository.scenarios.list()) == 1
+
+    async def test_scenario_round_trip(
+        self,
+        repository: SQLAlchemyRepository,
+        new_scenario,
+        a_dataset,
+        get_model_config_validator,
+    ):
+        validator = await get_model_config_validator()
+
+        scenario_id = await repository.scenarios.create(new_scenario, validator)
+        result = await repository.scenarios.for_id(scenario_id).get_by_id()
+        assert result is not None
+
+        assert result.id is not None
+        assert result.created_at is not None
+        assert result.updated_at is not None
+        assert result.datasets[0].pop("id") == a_dataset.id
+        assert (
+            dataclasses.replace(result, id=None, created_at=None, updated_at=None) == new_scenario
+        )
+
+    async def test_create_scenario_with_no_models_and_datasets(
+        self, repository: SQLAlchemyRepository, get_model_config_validator
+    ):
+        scenario_id = await repository.scenarios.create(
+            Scenario(
+                name="a_scenario",
+                display_name="a scenario",
+                description="",
+                epsg_code=0,
+            ),
+            validator=await get_model_config_validator(),
+        )
+        assert scenario_id is not None
+
+    async def test_get_scenario_by_name(self, repository: SQLAlchemyRepository, a_scenario):
+        result = await repository.scenarios.get_by_name(a_scenario.name)
+        assert result is not None
+
+    async def test_scenario_exists(
+        self, repository: SQLAlchemyRepository, new_scenario, get_model_config_validator
+    ):
+        assert not await repository.scenarios.exists_by_name(new_scenario.name)
+
+        validator = await get_model_config_validator()
+        await repository.scenarios.create(new_scenario, validator)
+
+        assert await repository.scenarios.exists_by_name(new_scenario.name)
+
+    async def test_update_scenario(
+        self, repository: SQLAlchemyRepository, a_scenario: Scenario, get_model_config_validator
+    ):
+
+        validator = await get_model_config_validator()
+
+        assert a_scenario is not None
+        assert a_scenario.id is not None
+
+        a_scenario.name = "new_name"
+        a_scenario.models = list(reversed(a_scenario.models))
+        await repository.scenarios.for_id(a_scenario.id).update(a_scenario, validator)
+
+        result = await repository.scenarios.for_id(a_scenario.id).get_by_id()
+
+        assert result is not None
+        assert result.name == a_scenario.name
+        assert result.models == a_scenario.models
+
+    async def test_delete_scenario_deletes_scenario_datasets(
+        self, repository: SQLAlchemyRepository, a_scenario
+    ):
+        query = (
+            select(func.count())
+            .select_from(db.ScenarioDataset)
+            .where(db.ScenarioDataset.scenario_id == a_scenario.id)
+        )
+        assert (await repository.session.scalar(query)) != 0
+        await repository.scenarios.for_id(a_scenario.id).delete()
+        assert len(await repository.scenarios.list()) == 0
+        assert (await repository.session.scalar(query)) == 0
+
+    async def test_delete_scenario_deletes_scenario_models(
+        self, repository: SQLAlchemyRepository, a_scenario
+    ):
+        query = (
+            select(func.count())
+            .select_from(db.ScenarioModel)
+            .where(db.ScenarioModel.scenario_id == a_scenario.id)
+        )
+        assert (await repository.session.scalar(query)) != 0
+        await repository.scenarios.for_id(a_scenario.id).delete()
+        await repository.session.commit()
+        assert len(await repository.scenarios.list()) == 0
+        assert (await repository.session.scalar(query)) == 0
+
+
+class TestUpdateRepository:
+    @pytest.fixture
+    def repository_for_scenario(self, repository: SQLAlchemyRepository, a_scenario):
+        return repository.for_scenario(a_scenario.id)
+
+    @pytest.mark.xfail
+    async def test_update_round_trip(
+        self,
+        a_scenario,
+        a_dataset,
+        an_entity_type,
+        an_attribute_type,
+        repository_for_scenario: SQLAlchemyRepository,
+    ):
+        update = Update(
+            dataset=ScenarioDataset(a_dataset.name, a_dataset.dataset_type.name),
+            timestamp=12,
+            iteration=2,
+            model_name=a_scenario.models[0]["name"],
+            model_type=a_scenario.models[0]["type"],
+            data={
+                an_entity_type.name: {
+                    "id": {"data": np.asarray([0, 1])},
+                    an_attribute_type.name: {"data": np.asarray([1.0, 2.0])},
+                }
+            },
+        )
+
+        update_id = await repository_for_scenario.updates.create(update)
+
+        result = await repository_for_scenario.updates.get_by_id(update_id)
+        assert result is not None
+        assert dataclasses.replace(update, data=None, id=update_id) == dataclasses.replace(
+            result, data=None
+        )
+        assert_dataset_dicts_equal(update.data, result.data)
+
+    async def test_updates_exist(
+        self, create_update, repository_for_scenario: SQLAlchemyRepository
+    ):
+        assert not await repository_for_scenario.updates.exists()
+        await create_update(timestamp=1, iteration=0, ids=[0, 1], array=[1.0, 2.0])
+
+        assert await repository_for_scenario.updates.exists()
+
+    async def test_gets_all_updates_in_order(
+        self, create_update, repository_for_scenario: SQLAlchemyRepository
+    ):
+        update1 = await create_update(timestamp=1, iteration=0, ids=[0, 1], array=[1.0, 2.0])
+        update4 = await create_update(timestamp=6, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        update2 = await create_update(timestamp=2, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        update3 = await create_update(timestamp=2, iteration=2, ids=[0, 1], array=[2.0, 3.0])
+        all_updates = await repository_for_scenario.updates.list()
+        assert [upd.id for upd in all_updates] == [update1, update2, update3, update4]
+
+    async def test_deletes_all_updates_for_scenario_but_not_others(
+        self,
+        a_scenario,
+        create_update,
+        repository_for_scenario: SQLAlchemyRepository,
+        create_scenario,
+    ):
+        another_scenario_id = await create_scenario(
+            dataclasses.replace(a_scenario, name="another_scenario")
+        )
+        await create_update(timestamp=6, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(timestamp=2, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(timestamp=2, iteration=2, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(
+            scenario_id=another_scenario_id, timestamp=1, iteration=0, ids=[0, 1], array=[1.0, 2.0]
+        )
+
+        assert len(await repository_for_scenario.updates.list()) == 3
+        assert (
+            len(await repository_for_scenario.for_scenario(another_scenario_id).updates.list())
+            == 1
+        )
+
+        await repository_for_scenario.updates.delete_all()
+
+        assert len(await repository_for_scenario.updates.list()) == 0
+        assert (
+            len(await repository_for_scenario.for_scenario(another_scenario_id).updates.list())
+            == 1
+        )

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -1058,6 +1058,7 @@ class TestUpdateRepository:
 
         result = await repository_for_scenario.updates.get_by_id(update_id)
         assert result is not None
+        assert result.created_at is not None
         assert dataclasses.replace(update, data=None, id=update_id) == dataclasses.replace(
             result, data=None
         )

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -30,6 +30,7 @@ from movici_data_core.domain_model import (
 from movici_data_core.exceptions import (
     InvalidAction,
     InvalidResource,
+    MoviciValidationError,
     ResourceAlreadyExists,
     ResourceDoesNotExist,
 )
@@ -1025,6 +1026,18 @@ class TestScenarioRepository:
         assert len(await repository.scenarios.list()) == 0
         assert (await repository.session.scalar(query)) == 0
 
+    async def test_create_invalid_scenario(
+        self, repository: SQLAlchemyRepository, new_scenario: Scenario, get_model_config_validator
+    ):
+        del new_scenario.models[0]["type"]
+        validator = await get_model_config_validator()
+
+        with pytest.raises(MoviciValidationError) as e:
+            await repository.scenarios.create(new_scenario, validator)
+
+        path, _ = next(iter(e.value.iter_messages()))
+        assert path == "models.0"
+
 
 class TestUpdateRepository:
     @pytest.fixture
@@ -1112,3 +1125,28 @@ class TestUpdateRepository:
             len(await repository_for_scenario.for_scenario(another_scenario_id).updates.list())
             == 1
         )
+
+    async def test_deletes_all_underlying_data(
+        self,
+        a_scenario,
+        create_update,
+        repository_for_scenario: SQLAlchemyRepository,
+        create_scenario,
+        session,
+    ):
+
+        another_scenario_id = await create_scenario(
+            dataclasses.replace(a_scenario, name="another_scenario")
+        )
+        await create_update(timestamp=6, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(timestamp=2, iteration=1, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(timestamp=2, iteration=2, ids=[0, 1], array=[2.0, 3.0])
+        await create_update(
+            scenario_id=another_scenario_id, timestamp=1, iteration=0, ids=[0, 1], array=[1.0, 2.0]
+        )
+
+        assert (await session.scalar(select(func.count(db.DataArray.id)))) == 8
+
+        await repository_for_scenario.updates.delete_all()
+
+        assert (await session.scalar(select(func.count(db.DataArray.id)))) == 2

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -23,6 +23,7 @@ from movici_data_core.domain_model import (
     ModelType,
     Scenario,
     ScenarioDataset,
+    SimulationInfo,
     Update,
     Workspace,
 )
@@ -903,7 +904,7 @@ class TestScenarioRepository:
             display_name="Some Scenario",
             description="Scenario for testing",
             epsg_code=28992,
-            simulation_info={"some": "info"},
+            simulation_info=SimulationInfo.default(),
             datasets=[
                 {
                     "name": a_dataset.name,

--- a/packages/data-core/tests/database/test_repository.py
+++ b/packages/data-core/tests/database/test_repository.py
@@ -692,7 +692,8 @@ class TestDatasetDataRepository:
     @pytest.mark.parametrize(
         "datatype, values, min_val, max_val",
         [
-            (bool, [False, False], False, True),
+            (bool, [False, False], False, False),
+            (bool, [True, False], False, True),
             (int, [2, -1], -1, 2),
             (float, [0.0, np.nan], 0.0, 0.0),
             (float, [np.nan], None, None),
@@ -714,7 +715,7 @@ class TestDatasetDataRepository:
 
         await repository.dataset_data.create(
             a_dataset.id,
-            {an_entity_type.name: {"some.attr": {"data": np.asarray(values)}}},
+            {an_entity_type.name: {"some.attr": {"data": np.asarray(values, dtype=datatype)}}},
             format=DatasetFormat.ENTITY_BASED,
         )
         attribute = await repository.session.scalar(

--- a/packages/data-core/tests/test_exceptions.py
+++ b/packages/data-core/tests/test_exceptions.py
@@ -1,0 +1,36 @@
+from movici_data_core.exceptions import MoviciValidationError
+from movici_simulation_core.validate import validate_and_process
+
+
+def test_error_with_single_message():
+    assert list(MoviciValidationError("some errormessage", path="some.path").iter_messages()) == [
+        ("some.path", "some errormessage"),
+    ]
+
+
+def test_consume_error_with_prefix():
+    error = MoviciValidationError(path="some.root")
+    error.consume(MoviciValidationError("some errormessage", path="some.path"))
+    assert list(error.iter_messages()) == [
+        ("some.root.some.path", "some errormessage"),
+    ]
+
+
+def test_consume_jsonschema_validation_error():
+    schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "key": {
+                "type": "array",
+                "items": {"type": "number"},
+            }
+        },
+    }
+    obj = {"additional": "val", "key": [0, "invalid"]}
+    _, errors = validate_and_process(obj, schema, return_errors=True)
+
+    error = MoviciValidationError.from_errors(errors, path="prefix")
+
+    assert list(m[0] for m in error.iter_messages()) == ["prefix", "prefix.key.1"]

--- a/packages/data-core/tests/test_validators.py
+++ b/packages/data-core/tests/test_validators.py
@@ -1,0 +1,73 @@
+import pytest
+
+from movici_data_core.domain_model import ScenarioDataset, ScenarioModel
+from movici_data_core.exceptions import MoviciValidationError
+from movici_data_core.validators import ModelConfigValidator
+from movici_simulation_core.validate import MoviciDataRefInfo
+
+
+@pytest.fixture
+def scenario_datasets():
+    return [
+        ScenarioDataset("some_dataset", "some_type"),
+        ScenarioDataset("another_dataset", "another_type"),
+    ]
+
+
+@pytest.fixture
+async def validator(default_model_types, scenario_datasets, get_model_config_validator):
+    return (await get_model_config_validator()).for_scenario(
+        scenario_datasets, default_model_types
+    )
+
+
+def test_scenario_model_validator(validator: ModelConfigValidator, default_model_types):
+    configs = [
+        {
+            "name": "model1",
+            "type": "model_a",
+            "dataset": "some_dataset",
+            "entity_group": "transport_nodes",
+            "attribute": "id",
+        },
+        {
+            "name": "model2",
+            "type": "model_b",
+            "field": "some string",
+        },
+    ]
+    model_1, model_2 = validator.process_model_configs(configs)
+    assert model_1 == ScenarioModel(
+        name="model1",
+        type=default_model_types[0],
+        config=configs[0],
+        references=[
+            MoviciDataRefInfo(("dataset",), "some_dataset", movici_type="dataset"),
+            MoviciDataRefInfo(("entity_group",), "transport_nodes", movici_type="entityGroup"),
+            MoviciDataRefInfo(("attribute",), "id", movici_type="attribute"),
+        ],
+    )
+    assert model_2 == ScenarioModel(
+        name="model2",
+        type=default_model_types[1],
+        config=configs[1],
+        references=[],
+    )
+
+
+@pytest.mark.parametrize(
+    "config, path",
+    [
+        ({}, "0"),
+        ({"type": 42}, "0.type"),
+        ({"type": "invalid"}, "0.type"),
+        ({"type": "model_a"}, "0"),
+        ({"type": "model_a", "name": 42}, "0.name"),
+        ({"type": "model_b", "name": "model", "field": 123}, "0.field"),
+    ],
+)
+def test_raises_on_invalid_config(config, path, validator):
+    with pytest.raises(MoviciValidationError) as e:
+        validator.process_model_configs([config])
+    error_path = list(e.value.iter_messages())[0][0]
+    assert error_path == path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,9 @@ name = "movici"
 dynamic = ["version"]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-  "movici-simulation-core",
+  "movici-data-core",
   "movici-drinking-water-model",
+  "movici-simulation-core",
   "movici-transport-assignment-model",
 ]
 
@@ -37,6 +38,7 @@ Issues = "https://github.com/nginfra/movici-simulation-core/issues"
 
 [tool.uv.sources]
 movici-simulation-core = { workspace = true }
+movici-data-core = { workspace = true }
 movici-drinking-water-model = { workspace = true }
 movici-transport-assignment-model = { workspace = true }
 
@@ -89,15 +91,19 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"packages/data-core/*" = ["S101", "B011"]
+"packages/data-core/tests/*" = ["S"]
+"packages/data-core/examples/*" = ["T20"]
+"packages/drinking-water/tests/*" = ["S"]
 "packages/simulation-core/tests/*" = ["S"]
 "packages/simulation-core/examples/*" = ["S101", "T20"]
-"packages/drinking-water/tests/*" = ["S"]
 "packages/transport-assignment/tests/*" = ["S"]
 
 [tool.ruff.lint.isort]
 known-first-party = [
-  "movici_simulation_core",
+  "movici_data_core",
   "movici_drinking_water_model",
+  "movici_simulation_core",
   "movici_transport_assignment_model",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [dependency-groups]
 dev = [
   "movici-simulation-core[all]",
+  "movici-data-core[sqlite]",
   "pytest",
   "coverage",
   "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ minversion = "7.0"
 addopts = ["--tb=short", "--strict-markers", "--strict-config"]
 testpaths = ["tests"]
 filterwarnings = ["ignore:.*ABCs from 'collections'.*:DeprecationWarning"]
+asyncio_mode = "auto"                                                      # work with regular async @pytest.fixtures
 
 [tool.mypy]
 disallow_untyped_calls = true

--- a/uv.lock
+++ b/uv.lock
@@ -96,35 +96,12 @@ wheels = [
 ]
 
 [[package]]
-name = "annotated-doc"
-version = "0.0.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
-]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
-]
-
-[[package]]
-name = "anyio"
-version = "4.13.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -152,40 +129,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
-]
-
-[[package]]
-name = "backports-datetime-fromisoformat"
-version = "2.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/71/81/eff3184acb1d9dc3ce95a98b6f3c81a49b4be296e664db8e1c2eeabef3d9/backports_datetime_fromisoformat-2.0.3.tar.gz", hash = "sha256:b58edc8f517b66b397abc250ecc737969486703a66eb97e01e6d51291b1a139d", size = 23588, upload-time = "2024-12-28T20:18:15.017Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/4b/d6b051ca4b3d76f23c2c436a9669f3be616b8cf6461a7e8061c7c4269642/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f681f638f10588fa3c101ee9ae2b63d3734713202ddfcfb6ec6cea0778a29d4", size = 27561, upload-time = "2024-12-28T20:16:47.974Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/40/e39b0d471e55eb1b5c7c81edab605c02f71c786d59fb875f0a6f23318747/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cd681460e9142f1249408e5aee6d178c6d89b49e06d44913c8fdfb6defda8d1c", size = 34448, upload-time = "2024-12-28T20:16:50.712Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/28/7a5c87c5561d14f1c9af979231fdf85d8f9fad7a95ff94e56d2205e2520a/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:ee68bc8735ae5058695b76d3bb2aee1d137c052a11c8303f1e966aa23b72b65b", size = 27093, upload-time = "2024-12-28T20:16:52.994Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ba/f00296c5c4536967c7d1136107fdb91c48404fe769a4a6fd5ab045629af8/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8273fe7932db65d952a43e238318966eab9e49e8dd546550a41df12175cc2be4", size = 52836, upload-time = "2024-12-28T20:16:55.283Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/92/bb1da57a069ddd601aee352a87262c7ae93467e66721d5762f59df5021a6/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39d57ea50aa5a524bb239688adc1d1d824c31b6094ebd39aa164d6cadb85de22", size = 52798, upload-time = "2024-12-28T20:16:56.64Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ef/b6cfd355982e817ccdb8d8d109f720cab6e06f900784b034b30efa8fa832/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ac6272f87693e78209dc72e84cf9ab58052027733cd0721c55356d3c881791cf", size = 52891, upload-time = "2024-12-28T20:16:58.887Z" },
-    { url = "https://files.pythonhosted.org/packages/37/39/b13e3ae8a7c5d88b68a6e9248ffe7066534b0cfe504bf521963e61b6282d/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:44c497a71f80cd2bcfc26faae8857cf8e79388e3d5fbf79d2354b8c360547d58", size = 52955, upload-time = "2024-12-28T20:17:00.028Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/e4/70cffa3ce1eb4f2ff0c0d6f5d56285aacead6bd3879b27a2ba57ab261172/backports_datetime_fromisoformat-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:6335a4c9e8af329cb1ded5ab41a666e1448116161905a94e054f205aa6d263bc", size = 29323, upload-time = "2024-12-28T20:17:01.125Z" },
-    { url = "https://files.pythonhosted.org/packages/62/f5/5bc92030deadf34c365d908d4533709341fb05d0082db318774fdf1b2bcb/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2e4b66e017253cdbe5a1de49e0eecff3f66cd72bcb1229d7db6e6b1832c0443", size = 27626, upload-time = "2024-12-28T20:17:03.448Z" },
-    { url = "https://files.pythonhosted.org/packages/28/45/5885737d51f81dfcd0911dd5c16b510b249d4c4cf6f4a991176e0358a42a/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:43e2d648e150777e13bbc2549cc960373e37bf65bd8a5d2e0cef40e16e5d8dd0", size = 34588, upload-time = "2024-12-28T20:17:04.459Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6d/bd74de70953f5dd3e768c8fc774af942af0ce9f211e7c38dd478fa7ea910/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:4ce6326fd86d5bae37813c7bf1543bae9e4c215ec6f5afe4c518be2635e2e005", size = 27162, upload-time = "2024-12-28T20:17:06.752Z" },
-    { url = "https://files.pythonhosted.org/packages/47/ba/1d14b097f13cce45b2b35db9898957578b7fcc984e79af3b35189e0d332f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7c8fac333bf860208fd522a5394369ee3c790d0aa4311f515fcc4b6c5ef8d75", size = 54482, upload-time = "2024-12-28T20:17:08.15Z" },
-    { url = "https://files.pythonhosted.org/packages/25/e9/a2a7927d053b6fa148b64b5e13ca741ca254c13edca99d8251e9a8a09cfe/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4da5ab3aa0cc293dc0662a0c6d1da1a011dc1edcbc3122a288cfed13a0b45", size = 54362, upload-time = "2024-12-28T20:17:10.605Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/99/394fb5e80131a7d58c49b89e78a61733a9994885804a0bb582416dd10c6f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58ea11e3bf912bd0a36b0519eae2c5b560b3cb972ea756e66b73fb9be460af01", size = 54162, upload-time = "2024-12-28T20:17:12.301Z" },
-    { url = "https://files.pythonhosted.org/packages/88/25/1940369de573c752889646d70b3fe8645e77b9e17984e72a554b9b51ffc4/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8a375c7dbee4734318714a799b6c697223e4bbb57232af37fbfff88fb48a14c6", size = 54118, upload-time = "2024-12-28T20:17:13.609Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/46/f275bf6c61683414acaf42b2df7286d68cfef03e98b45c168323d7707778/backports_datetime_fromisoformat-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:ac677b1664c4585c2e014739f6678137c8336815406052349c85898206ec7061", size = 29329, upload-time = "2024-12-28T20:17:16.124Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/0f/69bbdde2e1e57c09b5f01788804c50e68b29890aada999f2b1a40519def9/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66ce47ee1ba91e146149cf40565c3d750ea1be94faf660ca733d8601e0848147", size = 27630, upload-time = "2024-12-28T20:17:19.442Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/1d/1c84a50c673c87518b1adfeafcfd149991ed1f7aedc45d6e5eac2f7d19d7/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8b7e069910a66b3bba61df35b5f879e5253ff0821a70375b9daf06444d046fa4", size = 34707, upload-time = "2024-12-28T20:17:21.79Z" },
-    { url = "https://files.pythonhosted.org/packages/71/44/27eae384e7e045cda83f70b551d04b4a0b294f9822d32dea1cbf1592de59/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:a3b5d1d04a9e0f7b15aa1e647c750631a873b298cdd1255687bb68779fe8eb35", size = 27280, upload-time = "2024-12-28T20:17:24.503Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7a/a4075187eb6bbb1ff6beb7229db5f66d1070e6968abeb61e056fa51afa5e/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec1b95986430e789c076610aea704db20874f0781b8624f648ca9fb6ef67c6e1", size = 55094, upload-time = "2024-12-28T20:17:25.546Z" },
-    { url = "https://files.pythonhosted.org/packages/71/03/3fced4230c10af14aacadc195fe58e2ced91d011217b450c2e16a09a98c8/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe5f793db59e2f1d45ec35a1cf51404fdd69df9f6952a0c87c3060af4c00e32", size = 55605, upload-time = "2024-12-28T20:17:29.208Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/0a/4b34a838c57bd16d3e5861ab963845e73a1041034651f7459e9935289cfd/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:620e8e73bd2595dfff1b4d256a12b67fce90ece3de87b38e1dde46b910f46f4d", size = 55353, upload-time = "2024-12-28T20:17:32.433Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/68/07d13c6e98e1cad85606a876367ede2de46af859833a1da12c413c201d78/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4cf9c0a985d68476c1cabd6385c691201dda2337d7453fb4da9679ce9f23f4e7", size = 55298, upload-time = "2024-12-28T20:17:34.919Z" },
-    { url = "https://files.pythonhosted.org/packages/60/33/45b4d5311f42360f9b900dea53ab2bb20a3d61d7f9b7c37ddfcb3962f86f/backports_datetime_fromisoformat-2.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:d144868a73002e6e2e6fef72333e7b0129cecdd121aa8f1edba7107fd067255d", size = 29375, upload-time = "2024-12-28T20:17:36.018Z" },
-    { url = "https://files.pythonhosted.org/packages/be/03/7eaa9f9bf290395d57fd30d7f1f2f9dff60c06a31c237dc2beb477e8f899/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90e202e72a3d5aae673fcc8c9a4267d56b2f532beeb9173361293625fe4d2039", size = 28980, upload-time = "2024-12-28T20:18:06.554Z" },
-    { url = "https://files.pythonhosted.org/packages/47/80/a0ecf33446c7349e79f54cc532933780341d20cff0ee12b5bfdcaa47067e/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2df98ef1b76f5a58bb493dda552259ba60c3a37557d848e039524203951c9f06", size = 28449, upload-time = "2024-12-28T20:18:07.77Z" },
 ]
 
 [[package]]
@@ -701,15 +644,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dnspython"
-version = "2.8.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
-]
-
-[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -746,19 +680,6 @@ wheels = [
 ]
 
 [[package]]
-name = "email-validator"
-version = "2.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dnspython" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -768,159 +689,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
-]
-
-[[package]]
-name = "fastapi"
-version = "0.136.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "email-validator" },
-    { name = "fastapi-cli", extra = ["standard"] },
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "pydantic-extra-types" },
-    { name = "pydantic-settings" },
-    { name = "python-multipart" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[[package]]
-name = "fastapi-cli"
-version = "0.0.24"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "rich-toolkit" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304, upload-time = "2026-02-24T10:45:09.552Z" },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "fastapi-cloud-cli" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[[package]]
-name = "fastapi-cloud-cli"
-version = "0.17.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastar" },
-    { name = "httpx" },
-    { name = "pydantic", extra = ["email"] },
-    { name = "rich-toolkit" },
-    { name = "rignore" },
-    { name = "sentry-sdk" },
-    { name = "typer" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/96/57/cee8e91b83f39e75ae5562a2237261442a8179dcb3b631c7398113157398/fastapi_cloud_cli-0.17.1.tar.gz", hash = "sha256:0baece208fa88063bec46dccb5fb512f3199162092165e57654b44e64adbc44d", size = 47409, upload-time = "2026-04-27T13:38:07.094Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/a0/e252b68cf155409afabea037ab2971f41509481838847f6503fe890884ea/fastapi_cloud_cli-0.17.1-py3-none-any.whl", hash = "sha256:325e0199bdac7cb86f5df4f4a1d2070054095588088ef7b923a60cec458dcd63", size = 34046, upload-time = "2026-04-27T13:38:08.319Z" },
-]
-
-[[package]]
-name = "fastar"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238, upload-time = "2026-04-13T17:11:17.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/4a/0d79fe52243a4130aa41d0a3a9eea22e00427db761e1a6782ee817c50222/fastar-0.11.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e7c906ad371ca365591ebcb7630009923f3eceb20956814494d15591a78e9e46", size = 709786, upload-time = "2026-04-13T17:09:53.974Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/e4/77c94eaafc035e39f5ce5176e32743da4e3fe890f28790e708e53d8f75cd/fastar-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6919497b35fa5bd978d2c26ee117cf1771b90ee5073f7518e44b9bc364b57715", size = 632127, upload-time = "2026-04-13T17:09:39.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f6/97658dd992f4e45747d35adb24c0b100f6b6d451490685ae3fe8a3a2ee1b/fastar-0.11.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:56b50206aeedd99e22b83289e6fb3ff8f7d7da4407d2419902e4716b4f90585a", size = 869608, upload-time = "2026-04-13T17:09:08.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/fc/81c1ec4d8146a437399e7b95631b51be312f323a9ce64569f932db6c3914/fastar-0.11.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a1811a69ae81d469720df0c8af3f84f834a93b5e4f8be0e0e8bde6a52fa11f2", size = 762925, upload-time = "2026-04-13T17:07:52.788Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/35/49baf480ecb197aea7ce2515c503a2f25061958dd3b4c98e98a3a11cdcc7/fastar-0.11.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10486238c55589a3947c38f9cfb88a67d8a608eb8dddc722038237d0278a41d7", size = 759913, upload-time = "2026-04-13T17:08:07.324Z" },
-    { url = "https://files.pythonhosted.org/packages/94/eb/946f1980267f2824efb7d7c518d47a49b89c0e9cd7c449301f5a7531558a/fastar-0.11.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1555ef9992d368a6ec39092276990cef8d329c39a1d86ebd847eaa3b10efd472", size = 926054, upload-time = "2026-04-13T17:08:22.196Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/19/d5eb611085ce054382570d8d4e24a5e2ff23cd6d2404528a6643841d6059/fastar-0.11.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1f4aca0a9620b76988bbf6225cdea6678a392902444ca18bb8a51495b165a89", size = 818594, upload-time = "2026-04-13T17:08:52.366Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/52/18e8d55c0d3d917713f381cb2d0cb793da00c209c802e011d8dc72018cd5/fastar-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75beeecac7d11a666a6c4a0b7f7e80842ae5cf523f2f890b99c78fc82b403545", size = 823005, upload-time = "2026-04-13T17:09:23.051Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/b4/0fecdcf33e5aaffe777b96a1c10a3204fe0b05bf18e971033a0bfedafc1c/fastar-0.11.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a08cdf5d16daa401c65c9c7493a18db7dc515c52155a17071ec7098bb07da9d3", size = 887115, upload-time = "2026-04-13T17:08:37.385Z" },
-    { url = "https://files.pythonhosted.org/packages/08/f8/2a6ad1c2523eb72a4595a9331162fc67ce0f0aee3348728598026c516986/fastar-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6e210375e5a7ba53586cbd6017aa417d2d2ceacbe8671682470281bd0a15e8ef", size = 973595, upload-time = "2026-04-13T17:10:09.258Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/a6/2aa48843228673feacc2b80876b8924e63ea9c5f5f607bd7a72416b86bae/fastar-0.11.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a2988eb2604b8e15670f355425e8c800e4dcd4edfbcbfe194397f8f17b7eb19e", size = 1036988, upload-time = "2026-04-13T17:10:26.133Z" },
-    { url = "https://files.pythonhosted.org/packages/92/ac/3dd14b21c323e8484f47c910110d1d93139ba44621ac2c4c597dbe9fcdb7/fastar-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:34abc857b46068fdf91d157bd0203bfd6791dc7a432d1ed180f5af6c2f5bcce9", size = 1078267, upload-time = "2026-04-13T17:10:43.645Z" },
-    { url = "https://files.pythonhosted.org/packages/de/a1/3f89e58d6fa99160c9e7e17220c8ab5040b5cc017c4fac2356c6ed18453d/fastar-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0d884be84e37a01053776395441fc960031974e0265801ce574efc3d05e0cdaf", size = 1032551, upload-time = "2026-04-13T17:11:00.667Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/ea/24dd3cfc2096933d7d2a80c926e79602cff1fa481124ed2165b60c1dd9ef/fastar-0.11.0-cp310-cp310-win32.whl", hash = "sha256:c721c1ad758e3e4c2c1fd9e96911a0fa58c0a6be5668f1bcfd0b741e72c7cb63", size = 456022, upload-time = "2026-04-13T17:11:41.859Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ef/6eb39ee9cdd59822d1c7337c4d28fdc948885bdf455af9e70efa9879e06f/fastar-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba4180b7c3080f55f9035fdd7d8c39fe0e1485087a68ff615bb4784a10b8106b", size = 488392, upload-time = "2026-04-13T17:11:27.486Z" },
-    { url = "https://files.pythonhosted.org/packages/11/7a/fb367bdaf4efa2c7952a45aeab2e87a564293ecffe150af673ec8edfda46/fastar-0.11.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b82fd6f996e65a86f67a6bd64dd22ef3e8ae2dcaed0ae3b550e71f7e1bbb1df5", size = 709869, upload-time = "2026-04-13T17:09:55.62Z" },
-    { url = "https://files.pythonhosted.org/packages/80/ff/b87efb0dcfd081c62c7c7601d7681dabe63103cd51fc16f8d57a1ab45961/fastar-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27eed386fd0558e6daa29211111bbd7b740f7c7e881197f8a00ac7c0f3cdb1d7", size = 631668, upload-time = "2026-04-13T17:09:40.537Z" },
-    { url = "https://files.pythonhosted.org/packages/24/7c/0ed6dd38b9adc04b3a8ec3b7045908e7c2170ba0ff6e6d2c51bc9fc770f3/fastar-0.11.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a6931bebc1d8e95ddeef55732c195449e6b44ef33aa31b325505097ed3b4d6aa", size = 869663, upload-time = "2026-04-13T17:09:09.78Z" },
-    { url = "https://files.pythonhosted.org/packages/58/ce/8b7fb3f23855accebaaf2d2637eac7f261a7a5d936f861a172079f1ef511/fastar-0.11.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f72ce42a5e28a74fbd4d5fbf1a3ac1a1163d13cbc200cbd005fb0fabc54bd", size = 762938, upload-time = "2026-04-13T17:07:54.51Z" },
-    { url = "https://files.pythonhosted.org/packages/07/cc/5491e2b677bb841f768e3aba052d0344338a5c78aa5d4c18b443831a8e8d/fastar-0.11.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b83c1f61f7017d6e1498568038f8745440cfc16ca2f697ec81bac83050108f6", size = 759232, upload-time = "2026-04-13T17:08:08.864Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/b7/643630bdbd179e41e9fae31c03b4cf6061dbf4d6fbbae8425d16eb12545d/fastar-0.11.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db73a9b765a516e73983b25341e7b5e0189733878279e278b2295131b0e3a21e", size = 926271, upload-time = "2026-04-13T17:08:23.68Z" },
-    { url = "https://files.pythonhosted.org/packages/09/5d/37ade50003b4540e0a53ef100f6692d7ab2ac1122d5acf39920cc09a3e8b/fastar-0.11.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:625827d52eb4e8fec942e0233f125ff8010fcf6a67c0a974a8e5f4666b771e3c", size = 818634, upload-time = "2026-04-13T17:08:54.268Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/ff/135d177de32cc1e837c99019e4643e6e79352bde49544d4ece5b5eebf56b/fastar-0.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7f5fd8fa21ec0a88296a38dc5d7fc35efd3b26d46a17b8b7c73c5563925ca15", size = 822755, upload-time = "2026-04-13T17:09:25.01Z" },
-    { url = "https://files.pythonhosted.org/packages/27/cb/b835dbe76ceac7fa6105851468c259ffd06830eb9c029402e499d0ec153b/fastar-0.11.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8c15af91b8cd87ddf23ea55355ae513c1de3ab67178f26dad017c9e9c0af6096", size = 887101, upload-time = "2026-04-13T17:08:39.248Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/54/aa8289eb57fc550535470397cb051f5a58a7c89ca4de31d5502b916dd894/fastar-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a112395a8b0bff251423bd1564c012f0cc058ad8b6bd8fba96f3d7fc117e44", size = 973606, upload-time = "2026-04-13T17:10:10.98Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/fd/776d50a0897c01dc6bfd0926772ee913436fdae91b9affaf0a0cbd09f0a1/fastar-0.11.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f2994bb8f5f8c11eb12beae1e6e77a907173c9819236b8a4c8f0573652ceccce", size = 1036696, upload-time = "2026-04-13T17:10:28.502Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/cf0f9b499fb37ac065c8a01ec642f96a3c5eb849c38ae983b59f3b3245e0/fastar-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dcf99e4b5973d842c7f19c776c3a83cdc0977d505edce6206438505c0456b517", size = 1078182, upload-time = "2026-04-13T17:10:45.318Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/9e/21e4701aec4a1123d4dc4d31578dc18875582b5710e4725f7ceb752a248b/fastar-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29c9c386dc0d5dda78845a8e6b1480d26ab861c1e0b68f42ae5735cb70ca07f1", size = 1032336, upload-time = "2026-04-13T17:11:02.364Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/e2/5872b28c72c27ec1a00760eace6ff35f714f41ebbd5208cf016b12e29250/fastar-0.11.0-cp311-cp311-win32.whl", hash = "sha256:030b2580fc394f2c9b7890b6735810404e9b9ed5e0344db150b945965b5482b7", size = 457368, upload-time = "2026-04-13T17:11:43.528Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/6e/ce6832a16193eb4466f4108be8809c249b51cb1f89dd7894545700d079d5/fastar-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:83ab57ae067969cd0b483ac3b6dccc4b595fc77f5c820760998648d4c42822b5", size = 488605, upload-time = "2026-04-13T17:11:29.161Z" },
-    { url = "https://files.pythonhosted.org/packages/15/5a/9cfb80661cf38fd7b0889224beb7d2746784d4ade2a931ed9775a18d8602/fastar-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:27b1a4cee2298b704de8151d310462ee7335ed036011ca9aa6e784b30b6c73a9", size = 464580, upload-time = "2026-04-13T17:11:18.583Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/06/a5773706afc8bd496769786590bbc56d2d0ee419a299cc12ea3f5717fcf3/fastar-0.11.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3c51f1c2cdddbd1420d2897ace7738e36c65e17f6ae84e0bfe763f8d1068bb97", size = 708394, upload-time = "2026-04-13T17:09:57.269Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a6/d5e2a4e48495616440a21eed07558219ca90243ad00b0502586f95bd4833/fastar-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0d9d6b052baf5380baea866675dab6ccd04ec2460d12b1c46f10ce3f4ee6a820", size = 628417, upload-time = "2026-04-13T17:09:42.145Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/69/9816d69ac8265c9e50456637a487ccfb7a9c566efd9dbcd673df9c2558c2/fastar-0.11.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd2f05666d4df7e14885b5c38fefd92a785917387513d33d837ff42ec143a22f", size = 863950, upload-time = "2026-04-13T17:09:11.506Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/0d/f88daad53aff2e754b6b5ff2a7113f72447a34f6ef17cc23ca99988117b7/fastar-0.11.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e6e74aba1ae77ca4aedcaf1697cd413319f4c88a5ccbe5b42c709517c5097e", size = 760737, upload-time = "2026-04-13T17:07:55.958Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/a6/82ef4ecd969d50d92ed3ed9dbd8fe77faa24be5e5736f716edc9f4ce8d62/fastar-0.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38ef77fe940bbc9b37a98bd838727f844b11731cd39358a2640ff864fb385086", size = 757603, upload-time = "2026-04-13T17:08:10.623Z" },
-    { url = "https://files.pythonhosted.org/packages/03/35/50249f0d827251f8ac511495e2eacccebda80a00a0ad73e9615b8113b84f/fastar-0.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8955e61b32d6aff82c983217abf80933fd823b0e727586fc72f08043d996fd59", size = 923952, upload-time = "2026-04-13T17:08:25.526Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/d8/faee41659e9c379d906d24eaee6d6833ac8cfef0a5df480e5c2a8d3efb33/fastar-0.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:483532442cdb08fbff0169510224eae0836f2f672cea6aacb52847d90fefdc46", size = 816574, upload-time = "2026-04-13T17:08:56.076Z" },
-    { url = "https://files.pythonhosted.org/packages/22/47/0448ea7992b997dad2bf004bfd98eca74b5858630eae080b50c7b17d9ddc/fastar-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef5a6071121e05d8287fc75bccb054bcbac8bb0501200a0c0a8feeace5303ea4", size = 819382, upload-time = "2026-04-13T17:09:26.66Z" },
-    { url = "https://files.pythonhosted.org/packages/33/ef/0d63eb43586831b7a6f8b22c4d77125a7c594423af1f4f090fa9541b9b40/fastar-0.11.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:e45e598af5afe8412197d4786efd6cf29be02e7d3d4f6a3461149eae5d7e94f1", size = 885254, upload-time = "2026-04-13T17:08:40.9Z" },
-    { url = "https://files.pythonhosted.org/packages/01/25/edd584675d69e49a165052c3ee886df1c5d574f3e7d813c990306387c623/fastar-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e160919b1c47ddb8538e7e8eb4cd527281b40f0bf75110a75993838ef61f286", size = 971239, upload-time = "2026-04-13T17:10:12.997Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/37/e8bb24f506ba2b08fbaf36c5800e843bd4d542954e9331f00418e2d23349/fastar-0.11.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4bb4dc0fc8f7a6807febcebce8a2f3626ba4955a9263d81ecc630aad83be84c0", size = 1035185, upload-time = "2026-04-13T17:10:30.207Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/bf/be753736296338149ee4cb3e92e2b5423d6ba17c7b951d15218fd7e99bbf/fastar-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4ec95af56aa173f6e320e1183001bf108ba59beaf13edd1fc8200648db203588", size = 1072191, upload-time = "2026-04-13T17:10:47.072Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/cd/a81c1aaafb5a22ce57c98ae22f39c89413ed53e4ee6e1b1444b0bd666a6c/fastar-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:136cf342735464091c39dc3708168f9fdeb9ebea40b1ead937c61afaf46143d9", size = 1028054, upload-time = "2026-04-13T17:11:04.293Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/88/1ce4eed3d70627c95f49ca017f6bbbf2ddcc4b0c601d293259de7689bc20/fastar-0.11.0-cp312-cp312-win32.whl", hash = "sha256:35f23c11b556cc4d3704587faacbc0037f7bdf6c4525cd1d09c70bda4b1c6809", size = 454198, upload-time = "2026-04-13T17:11:45.168Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/1d/26ce92f4331cd61a69840db9ca6115829805eec24f285481a854f578e917/fastar-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:920bc56c3c0b8a8ca492904941d1883c1c947c858cd93343356c29122a38f44c", size = 486697, upload-time = "2026-04-13T17:11:31.084Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/96/e6eda4480559c69b05d466e7b5ea9170e81fef3795a73e059959a3258319/fastar-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:395248faf89e8a6bd5dc1fd544c8465113b627cb6d7c8b296796b60ebea33593", size = 462591, upload-time = "2026-04-13T17:11:20.577Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/d6/3be260037e86fb694e88d47f583bac3a0188c99cee1a6b257ac26cb6b53c/fastar-0.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:33f544b08b4541b678e53749b4552a44720d96761fb79c172b005b1089c443ed", size = 707975, upload-time = "2026-04-13T17:09:58.866Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/cd/7867aefb1784662554a335f2952c75a50f0c70585ed0d2210d6cc15e5627/fastar-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c1c792447e4a642745f347ff9847c52af39633071c57ee67ed53c157fc3506", size = 628460, upload-time = "2026-04-13T17:09:43.776Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/2b/d11d84bdd5e0e377771b955755771e3460b290da5809cb78c1b735ee2228/fastar-0.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:881247e6b6eaea59fc6569f9b61447aa6b9fc2ee864e048b4643d69c52745805", size = 863054, upload-time = "2026-04-13T17:09:13.048Z" },
-    { url = "https://files.pythonhosted.org/packages/25/39/d3f428b318fa940b1b6e785b8d54fc895dfb5d5b945ef8d5442ffa904fb2/fastar-0.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:863b7929845c9fec92ef6c8d59579cf46af5136655e5342f8df5cebe46cab06c", size = 760247, upload-time = "2026-04-13T17:07:57.396Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/04/03949aee82aabb8ede06ac5a4a5579ffaf98a8fe59ce958494508ff15513/fastar-0.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96b4a57df12bf3211662627a3ea29d62ecb314a2434a0d0843f9fc23e47536e5", size = 756512, upload-time = "2026-04-13T17:08:12.415Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/0c/2ca1ae0a3828ca51047962d932b80daca2522db73e8cb9d040cb6ebe28d5/fastar-0.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ceef1c2c4df7b7b8ebd3f5d718bbf457b9bbdf25ce0bd07870211ec4fbd9aff4", size = 922183, upload-time = "2026-04-13T17:08:27.187Z" },
-    { url = "https://files.pythonhosted.org/packages/65/68/7fe808b1f73a68e686f25434f538c6dc10ef4dfb3db0ace22cd861744bf8/fastar-0.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8e545918441910a779659d4759ad0eef349e935fbdb4668a666d3681567eb05", size = 816394, upload-time = "2026-04-13T17:08:57.657Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/17/07d086080f8a83b8d7966955e29bcdbd6a060f5bd949dc9d5abd3658cead/fastar-0.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28095bb8f821e85fc2764e1a55f03e5e2876dee2abe7cd0ee9420d929905d643", size = 818983, upload-time = "2026-04-13T17:09:28.46Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/e2/2c4edf0910af2e814ff6d65b77a91196d472ca8a9fb2033bd983f6856caa/fastar-0.11.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0fafb95ecbe70f666a5e9b35dd63974ccdc9bb3d99ccdbd4014a823ec3e659b5", size = 884689, upload-time = "2026-04-13T17:08:42.763Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ba/04fdcbd6558e60de4ced3b55230fac47675d181252582b2fcec3c74608e5/fastar-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af48fed039b94016629dcdad1c95c90c486326dd068de2b0a4df419ee09b6821", size = 970677, upload-time = "2026-04-13T17:10:15.124Z" },
-    { url = "https://files.pythonhosted.org/packages/df/b3/2b860a9658550167dbd5824c85e88d0b4b912bf493e42a6322544d6e483d/fastar-0.11.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:74cd96163f39b8638ab4e8d49708ca887959672a22871d8170d01f067319533b", size = 1034026, upload-time = "2026-04-13T17:10:32.318Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/9b/fa42ea1188b144bac4b1b60753dfd449974a4d5eda132029ee7711569f94/fastar-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e8b993cb5613bab495ed482810bedc0986633fcb9a3b55c37ec88e0d6714f6a", size = 1071147, upload-time = "2026-04-13T17:10:48.833Z" },
-    { url = "https://files.pythonhosted.org/packages/95/c8/d2e501556dca9f1fbc9246111a31792fb49ad908fa4927f34938a97a3604/fastar-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfe39d91fc28e37e06162d94afe01050220edb7df554acb5b702b5503e564816", size = 1028377, upload-time = "2026-04-13T17:11:06.374Z" },
-    { url = "https://files.pythonhosted.org/packages/db/33/5f11f23eca0a569cd052507bc45dda2e5468697f8665728d25be44120f7d/fastar-0.11.0-cp313-cp313-win32.whl", hash = "sha256:c5f63d4d99ff4bfb37c659982ec413358bdee747005348756cc50a04d412d989", size = 454089, upload-time = "2026-04-13T17:11:46.821Z" },
-    { url = "https://files.pythonhosted.org/packages/da/2f/35ff03c939cba7a255a9132367873fec6c355fd06a7f84fedcbaf4c8129f/fastar-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8690ed1928d31ded3ada308e1086525fb3871f5fa81e1b69601a3f7774004583", size = 486312, upload-time = "2026-04-13T17:11:32.86Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/71/ee9246cbfcbfd4144558f35e7e9a306ffe0a7564730a5188c45f21d2dab8/fastar-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:d977ded9d98a0719a305e0a4d5ee811f1d3e856d853a50acb8ae833c3cd6d5d2", size = 461975, upload-time = "2026-04-13T17:11:22.589Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/5c/9bbeffbf1905391446dd98aa520422ce7affde5c9a7c22d757cc5d7c1397/fastar-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1266d6a004f427b0d61bd6c7b544d84cc964691b2232c2f4d635a1b75f2f6d5e", size = 711644, upload-time = "2026-04-13T17:10:07.663Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/af/ae5cf39d4fb82d0c592705f5ec6db1b065be5265c151b108f86126ee8773/fastar-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:298a827ec04ade43733f6ca960d0faec38706aa1494175869ea7ea17f5bad5d3", size = 634371, upload-time = "2026-04-13T17:09:52.083Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/36/8d4569e26473c72ccb02d1c5df3ed710073f1c06eca09c26d52ea79fd815/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8800e2387e463a0e5799416a1cbe72dd0fde7270a20e4bde684145e7878f6516", size = 870850, upload-time = "2026-04-13T17:09:21.439Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/46/724dc796e1756d3977970f820d30d59bb8cab8e3671b285f1d82ab513aec/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7496def0a2befd82d429cb004ef7ca831585cc887947bd6b9abb68a5ef852b0b", size = 764469, upload-time = "2026-04-13T17:08:05.638Z" },
-    { url = "https://files.pythonhosted.org/packages/99/e3/74d6859e632e8fb9339a14f652fb9f800c2bd6aa53071e311c0be3fbab8b/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:878eaf15463eb572e3538af7ca3a8534e5e279cf8196db902d24e5725c4af86e", size = 761375, upload-time = "2026-04-13T17:08:20.669Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/e7/cc70e2be5ef8731a7525552b1c35c1448cf9eae6a62cb3a56f12c1bf27ea/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0324ed1d1ef0186e1bbd843b17807d6d837d0906899d4c99378b02c5d86bdd9c", size = 928189, upload-time = "2026-04-13T17:08:35.663Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/33/c9a969e78dca323547276a6fee5f4f9588f7cd5ab45acec3778c67399589/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdf9bd863205590beaf8ef6e66f315310196632180dceaf674985d01a876cac3", size = 820864, upload-time = "2026-04-13T17:09:06.366Z" },
-    { url = "https://files.pythonhosted.org/packages/84/bd/6b9434b541fe55c125b5f2e017a565596a2d215aa09207e4555e4585064f/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59af8dbb683b24b90fb5b506de080faeab0a17a908e6c2a5d93a97260ed75d7b", size = 824060, upload-time = "2026-04-13T17:09:37.377Z" },
-    { url = "https://files.pythonhosted.org/packages/24/8d/871d5f8cf4c6f13987119fb0a9ae8be131e34f2756c2524e9974adf33824/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:9f3df73a3c4292cfe15696cdf59cdb6c309ab59d30b34c733be13c6e32d9a264", size = 889217, upload-time = "2026-04-13T17:08:50.884Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/26/cca0fd2704f3ed20165e5613ed911549aef3aaf3b0b5b02fee0e8e23e6cc/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa3762cbb16e41a76b61f4a6914937a71aab3a7b6c2d82ca233bc686ebaf756b", size = 975418, upload-time = "2026-04-13T17:10:24.307Z" },
-    { url = "https://files.pythonhosted.org/packages/99/94/8bbb0b13f5b6cbe2492f0b7cbba5103e6163976a3331466d010e781fa189/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:a8c7bc8ac74cb359bb546b199288c83236372d094b402e557c197e85527495cd", size = 1038492, upload-time = "2026-04-13T17:10:41.939Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/d3/5b7df222a30eac2822ffd00f82fd4c2ce84fba4b369d1e1a03732fd177fc/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:587cbd060a2699c5f66281081395bb4657b2b1e0eef5c206b1aabf740019d670", size = 1080210, upload-time = "2026-04-13T17:10:58.462Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/6d/56ef943ea524784598c035ccbd42e564e937da0438ae3f55f0e76cb95571/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a1c56957ac82408be37a3f63594bc83e0919e8760492a4475e542f9f1828778", size = 1034886, upload-time = "2026-04-13T17:11:15.617Z" },
 ]
 
 [[package]]
@@ -1074,79 +842,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
     { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
     { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
-]
-
-[[package]]
-name = "h11"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
-]
-
-[[package]]
-name = "httpcore"
-version = "1.0.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
-]
-
-[[package]]
-name = "httptools"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/e5/c07e0bcf4ec8db8164e9f6738c048b2e66aabf30e7506f440c4cc6953f60/httptools-0.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11d01b0ff1fe02c4c32d60af61a4d613b74fad069e47e06e9067758c01e9ac78", size = 204531, upload-time = "2025-10-10T03:54:20.887Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/4f/35e3a63f863a659f92ffd92bef131f3e81cf849af26e6435b49bd9f6f751/httptools-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:84d86c1e5afdc479a6fdabf570be0d3eb791df0ae727e8dbc0259ed1249998d4", size = 109408, upload-time = "2025-10-10T03:54:22.455Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/71/b0a9193641d9e2471ac541d3b1b869538a5fb6419d52fd2669fa9c79e4b8/httptools-0.7.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8c751014e13d88d2be5f5f14fc8b89612fcfa92a9cc480f2bc1598357a23a05", size = 440889, upload-time = "2025-10-10T03:54:23.753Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/d9/2e34811397b76718750fea44658cb0205b84566e895192115252e008b152/httptools-0.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:654968cb6b6c77e37b832a9be3d3ecabb243bbe7a0b8f65fbc5b6b04c8fcabed", size = 440460, upload-time = "2025-10-10T03:54:25.313Z" },
-    { url = "https://files.pythonhosted.org/packages/01/3f/a04626ebeacc489866bb4d82362c0657b2262bef381d68310134be7f40bb/httptools-0.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b580968316348b474b020edf3988eecd5d6eec4634ee6561e72ae3a2a0e00a8a", size = 425267, upload-time = "2025-10-10T03:54:26.81Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/99/adcd4f66614db627b587627c8ad6f4c55f18881549bab10ecf180562e7b9/httptools-0.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d496e2f5245319da9d764296e86c5bb6fcf0cf7a8806d3d000717a889c8c0b7b", size = 424429, upload-time = "2025-10-10T03:54:28.174Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/72/ec8fc904a8fd30ba022dfa85f3bbc64c3c7cd75b669e24242c0658e22f3c/httptools-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cbf8317bfccf0fed3b5680c559d3459cccf1abe9039bfa159e62e391c7270568", size = 86173, upload-time = "2025-10-10T03:54:29.5Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
-    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
-    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
-    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
-    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
-    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
-    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
-]
-
-[[package]]
-name = "httpx"
-version = "0.28.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1393,18 +1088,6 @@ wheels = [
 ]
 
 [[package]]
-name = "markdown-it-py"
-version = "4.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdurl" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
-]
-
-[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1465,19 +1148,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-]
-
-[[package]]
-name = "marshmallow"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
 ]
 
 [[package]]
@@ -1542,15 +1212,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdurl"
-version = "0.1.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
 name = "movici"
 source = { editable = "." }
 dependencies = [
@@ -1610,14 +1271,11 @@ docs = [
 name = "movici-data-core"
 source = { editable = "packages/data-core" }
 dependencies = [
-    { name = "fastapi", extra = ["standard"] },
-    { name = "marshmallow" },
     { name = "movici-simulation-core" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "orjson" },
     { name = "sqlalchemy" },
-    { name = "svcs" },
 ]
 
 [package.optional-dependencies]
@@ -1633,13 +1291,10 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.22.1" },
-    { name = "fastapi", extras = ["standard"] },
-    { name = "marshmallow", specifier = ">=4.3.0" },
     { name = "movici-simulation-core", editable = "packages/simulation-core" },
     { name = "numpy" },
     { name = "orjson", specifier = ">=3.11.7" },
     { name = "sqlalchemy" },
-    { name = "svcs" },
 ]
 provides-extras = ["sqlite"]
 
@@ -2618,11 +2273,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
-]
-
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
@@ -2711,19 +2361,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
-]
-
-[[package]]
-name = "pydantic-extra-types"
-version = "2.11.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
 ]
 
 [[package]]
@@ -2964,15 +2601,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-multipart"
-version = "0.0.27"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
-]
-
-[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3117,124 +2745,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
-]
-
-[[package]]
-name = "rich"
-version = "15.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
-]
-
-[[package]]
-name = "rich-toolkit"
-version = "0.19.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "rich" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/3c/c923619f6d2f5fafcc96fec0aaf9550a46cd5b6481f06e0c6b66a2a4fed0/rich_toolkit-0.19.7-py3-none-any.whl", hash = "sha256:0288e9203728c47c5a4eb60fd2f0692d9df7455a65901ab6f898437a2ba5989d", size = 32963, upload-time = "2026-02-24T16:06:22.066Z" },
-]
-
-[[package]]
-name = "rignore"
-version = "0.7.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e5/f5/8bed2310abe4ae04b67a38374a4d311dd85220f5d8da56f47ae9361be0b0/rignore-0.7.6.tar.gz", hash = "sha256:00d3546cd793c30cb17921ce674d2c8f3a4b00501cb0e3dd0e82217dbeba2671", size = 57140, upload-time = "2025-11-05T21:41:21.968Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/7a/b970cd0138b0ece72eb28f086e933f9ed75b795716ad3de5ab22994b3b54/rignore-0.7.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f3c74a7e5ee77aea669c95fdb3933f2a6c7549893700082e759128a29cf67e45", size = 884999, upload-time = "2025-11-05T20:42:38.373Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/05/23faca29616d8966ada63fb0e13c214107811fa9a0aba2275e4c7ca63bd5/rignore-0.7.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b7202404958f5fe3474bac91f65350f0b1dde1a5e05089f2946549b7e91e79ec", size = 824824, upload-time = "2025-11-05T20:42:22.1Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/2e/05a1e61f04cf2548524224f0b5f21ca19ea58f7273a863bac10846b8ff69/rignore-0.7.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bde7c5835fa3905bfb7e329a4f1d7eccb676de63da7a3f934ddd5c06df20597", size = 899121, upload-time = "2025-11-05T20:40:48.94Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/35/71518847e10bdbf359badad8800e4681757a01f4777b3c5e03dbde8a42d8/rignore-0.7.6-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:626c3d4ba03af266694d25101bc1d8d16eda49c5feb86cedfec31c614fceca7d", size = 873813, upload-time = "2025-11-05T20:41:04.71Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/c8/32ae405d3e7fd4d9f9b7838f2fcca0a5005bb87fa514b83f83fd81c0df22/rignore-0.7.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a43841e651e7a05a4274b9026cc408d1912e64016ede8cd4c145dae5d0635be", size = 1168019, upload-time = "2025-11-05T20:41:20.723Z" },
-    { url = "https://files.pythonhosted.org/packages/25/98/013c955982bc5b4719bf9a5bea58be317eea28aa12bfd004025e3cd7c000/rignore-0.7.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7978c498dbf7f74d30cdb8859fe612167d8247f0acd377ae85180e34490725da", size = 942822, upload-time = "2025-11-05T20:41:36.99Z" },
-    { url = "https://files.pythonhosted.org/packages/90/fb/9a3f3156c6ed30bcd597e63690353edac1fcffe9d382ad517722b56ac195/rignore-0.7.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d22f72ab695c07d2d96d2a645208daff17084441b5d58c07378c9dd6f9c4c87", size = 959820, upload-time = "2025-11-05T20:42:06.364Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/b2/93bf609633021e9658acaff24cfb055d8cdaf7f5855d10ebb35307900dda/rignore-0.7.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d5bd8e1a91ed1a789b2cbe39eeea9204a6719d4f2cf443a9544b521a285a295f", size = 985050, upload-time = "2025-11-05T20:41:51.124Z" },
-    { url = "https://files.pythonhosted.org/packages/69/bc/ec2d040469bdfd7b743df10f2201c5d285009a4263d506edbf7a06a090bb/rignore-0.7.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bc1fc03efad5789365018e94ac4079f851a999bc154d1551c45179f7fcf45322", size = 1079164, upload-time = "2025-11-05T21:40:10.368Z" },
-    { url = "https://files.pythonhosted.org/packages/df/26/4b635f4ea5baf4baa8ba8eee06163f6af6e76dfbe72deb57da34bb24b19d/rignore-0.7.6-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:ce2617fe28c51367fd8abfd4eeea9e61664af63c17d4ea00353d8ef56dfb95fa", size = 1139028, upload-time = "2025-11-05T21:40:27.977Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/54/a3147ebd1e477b06eb24e2c2c56d951ae5faa9045b7b36d7892fec5080d9/rignore-0.7.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7c4ad2cee85068408e7819a38243043214e2c3047e9bd4c506f8de01c302709e", size = 1119024, upload-time = "2025-11-05T21:40:45.148Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/f4/27475db769a57cff18fe7e7267b36e6cdb5b1281caa185ba544171106cba/rignore-0.7.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:02cd240bfd59ecc3907766f4839cbba20530a2e470abca09eaa82225e4d946fb", size = 1128531, upload-time = "2025-11-05T21:41:02.734Z" },
-    { url = "https://files.pythonhosted.org/packages/97/32/6e782d3b352e4349fa0e90bf75b13cb7f11d8908b36d9e2b262224b65d9a/rignore-0.7.6-cp310-cp310-win32.whl", hash = "sha256:fe2bd8fa1ff555259df54c376abc73855cb02628a474a40d51b358c3a1ddc55b", size = 646817, upload-time = "2025-11-05T21:41:47.51Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/8a/53185c69abb3bb362e8a46b8089999f820bf15655629ff8395107633c8ab/rignore-0.7.6-cp310-cp310-win_amd64.whl", hash = "sha256:d80afd6071c78baf3765ec698841071b19e41c326f994cfa69b5a1df676f5d39", size = 727001, upload-time = "2025-11-05T21:41:32.778Z" },
-    { url = "https://files.pythonhosted.org/packages/25/41/b6e2be3069ef3b7f24e35d2911bd6deb83d20ed5642ad81d5a6d1c015473/rignore-0.7.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:40be8226e12d6653abbebaffaea2885f80374c1c8f76fe5ca9e0cadd120a272c", size = 885285, upload-time = "2025-11-05T20:42:39.763Z" },
-    { url = "https://files.pythonhosted.org/packages/52/66/ba7f561b6062402022887706a7f2b2c2e2e2a28f1e3839202b0a2f77e36d/rignore-0.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:182f4e5e4064d947c756819446a7d4cdede8e756b8c81cf9e509683fe38778d7", size = 823882, upload-time = "2025-11-05T20:42:23.488Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/81/4087453df35a90b07370647b19017029324950c1b9137d54bf1f33843f17/rignore-0.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16b63047648a916a87be1e51bb5c009063f1b8b6f5afe4f04f875525507e63dc", size = 899362, upload-time = "2025-11-05T20:40:51.111Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/c9/390a8fdfabb76d71416be773bd9f162977bd483084f68daf19da1dec88a6/rignore-0.7.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba5524f5178deca4d7695e936604ebc742acb8958f9395776e1fcb8133f8257a", size = 873633, upload-time = "2025-11-05T20:41:06.193Z" },
-    { url = "https://files.pythonhosted.org/packages/df/c9/79404fcb0faa76edfbc9df0901f8ef18568d1104919ebbbad6d608c888d1/rignore-0.7.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62020dbb89a1dd4b84ab3d60547b3b2eb2723641d5fb198463643f71eaaed57d", size = 1167633, upload-time = "2025-11-05T20:41:22.491Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/8d/b3466d32d445d158a0aceb80919085baaae495b1f540fb942f91d93b5e5b/rignore-0.7.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b34acd532769d5a6f153a52a98dcb81615c949ab11697ce26b2eb776af2e174d", size = 941434, upload-time = "2025-11-05T20:41:38.151Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/40/9cd949761a7af5bc27022a939c91ff622d29c7a0b66d0c13a863097dde2d/rignore-0.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c5e53b752f9de44dff7b3be3c98455ce3bf88e69d6dc0cf4f213346c5e3416c", size = 959461, upload-time = "2025-11-05T20:42:08.476Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/87/1e1a145731f73bdb7835e11f80da06f79a00d68b370d9a847de979575e6d/rignore-0.7.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:25b3536d13a5d6409ce85f23936f044576eeebf7b6db1d078051b288410fc049", size = 985323, upload-time = "2025-11-05T20:41:52.735Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/31/1ecff992fc3f59c4fcdcb6c07d5f6c1e6dfb55ccda19c083aca9d86fa1c6/rignore-0.7.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6e01cad2b0b92f6b1993f29fc01f23f2d78caf4bf93b11096d28e9d578eb08ce", size = 1079173, upload-time = "2025-11-05T21:40:12.007Z" },
-    { url = "https://files.pythonhosted.org/packages/17/18/162eedadb4c2282fa4c521700dbf93c9b14b8842e8354f7d72b445b8d593/rignore-0.7.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5991e46ab9b4868334c9e372ab0892b0150f3f586ff2b1e314272caeb38aaedb", size = 1139012, upload-time = "2025-11-05T21:40:29.399Z" },
-    { url = "https://files.pythonhosted.org/packages/78/96/a9ca398a8af74bb143ad66c2a31303c894111977e28b0d0eab03867f1b43/rignore-0.7.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6c8ae562e5d1246cba5eaeb92a47b2a279e7637102828dde41dcbe291f529a3e", size = 1118827, upload-time = "2025-11-05T21:40:46.6Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/22/1c1a65047df864def9a047dbb40bc0b580b8289a4280e62779cd61ae21f2/rignore-0.7.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaf938530dcc0b47c4cfa52807aa2e5bfd5ca6d57a621125fe293098692f6345", size = 1128182, upload-time = "2025-11-05T21:41:04.239Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/f4/1526eb01fdc2235aca1fd9d0189bee4021d009a8dcb0161540238c24166e/rignore-0.7.6-cp311-cp311-win32.whl", hash = "sha256:166ebce373105dd485ec213a6a2695986346e60c94ff3d84eb532a237b24a4d5", size = 646547, upload-time = "2025-11-05T21:41:49.439Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/c8/dda0983e1845706beb5826459781549a840fe5a7eb934abc523e8cd17814/rignore-0.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:44f35ee844b1a8cea50d056e6a595190ce9d42d3cccf9f19d280ae5f3058973a", size = 727139, upload-time = "2025-11-05T21:41:34.367Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/47/eb1206b7bf65970d41190b879e1723fc6bbdb2d45e53565f28991a8d9d96/rignore-0.7.6-cp311-cp311-win_arm64.whl", hash = "sha256:14b58f3da4fa3d5c3fa865cab49821675371f5e979281c683e131ae29159a581", size = 657598, upload-time = "2025-11-05T21:41:23.758Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/0e/012556ef3047a2628842b44e753bb15f4dc46806780ff090f1e8fe4bf1eb/rignore-0.7.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:03e82348cb7234f8d9b2834f854400ddbbd04c0f8f35495119e66adbd37827a8", size = 883488, upload-time = "2025-11-05T20:42:41.359Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b0/d4f1f3fe9eb3f8e382d45ce5b0547ea01c4b7e0b4b4eb87bcd66a1d2b888/rignore-0.7.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9e624f6be6116ea682e76c5feb71ea91255c67c86cb75befe774365b2931961", size = 820411, upload-time = "2025-11-05T20:42:24.782Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/c8/dea564b36dedac8de21c18e1851789545bc52a0c22ece9843444d5608a6a/rignore-0.7.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bda49950d405aa8d0ebe26af807c4e662dd281d926530f03f29690a2e07d649a", size = 897821, upload-time = "2025-11-05T20:40:52.613Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/2b/ee96db17ac1835e024c5d0742eefb7e46de60020385ac883dd3d1cde2c1f/rignore-0.7.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5fd5ab3840b8c16851d327ed06e9b8be6459702a53e5ab1fc4073b684b3789e", size = 873963, upload-time = "2025-11-05T20:41:07.49Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8c/ad5a57bbb9d14d5c7e5960f712a8a0b902472ea3f4a2138cbf70d1777b75/rignore-0.7.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ced2a248352636a5c77504cb755dc02c2eef9a820a44d3f33061ce1bb8a7f2d2", size = 1169216, upload-time = "2025-11-05T20:41:23.73Z" },
-    { url = "https://files.pythonhosted.org/packages/80/e6/5b00bc2a6bc1701e6878fca798cf5d9125eb3113193e33078b6fc0d99123/rignore-0.7.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a04a3b73b75ddc12c9c9b21efcdaab33ca3832941d6f1d67bffd860941cd448a", size = 942942, upload-time = "2025-11-05T20:41:39.393Z" },
-    { url = "https://files.pythonhosted.org/packages/85/e5/7f99bd0cc9818a91d0e8b9acc65b792e35750e3bdccd15a7ee75e64efca4/rignore-0.7.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d24321efac92140b7ec910ac7c53ab0f0c86a41133d2bb4b0e6a7c94967f44dd", size = 959787, upload-time = "2025-11-05T20:42:09.765Z" },
-    { url = "https://files.pythonhosted.org/packages/55/54/2ffea79a7c1eabcede1926347ebc2a81bc6b81f447d05b52af9af14948b9/rignore-0.7.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c7aa109d41e593785c55fdaa89ad80b10330affa9f9d3e3a51fa695f739b20", size = 984245, upload-time = "2025-11-05T20:41:54.062Z" },
-    { url = "https://files.pythonhosted.org/packages/41/f7/e80f55dfe0f35787fa482aa18689b9c8251e045076c35477deb0007b3277/rignore-0.7.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1734dc49d1e9501b07852ef44421f84d9f378da9fbeda729e77db71f49cac28b", size = 1078647, upload-time = "2025-11-05T21:40:13.463Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/cf/2c64f0b6725149f7c6e7e5a909d14354889b4beaadddaa5fff023ec71084/rignore-0.7.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5719ea14ea2b652c0c0894be5dfde954e1853a80dea27dd2fbaa749618d837f5", size = 1139186, upload-time = "2025-11-05T21:40:31.27Z" },
-    { url = "https://files.pythonhosted.org/packages/75/95/a86c84909ccc24af0d094b50d54697951e576c252a4d9f21b47b52af9598/rignore-0.7.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8e23424fc7ce35726854f639cb7968151a792c0c3d9d082f7f67e0c362cfecca", size = 1117604, upload-time = "2025-11-05T21:40:48.07Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/5e/13b249613fd5d18d58662490ab910a9f0be758981d1797789913adb4e918/rignore-0.7.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3efdcf1dd84d45f3e2bd2f93303d9be103888f56dfa7c3349b5bf4f0657ec696", size = 1127725, upload-time = "2025-11-05T21:41:05.804Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/28/fa5dcd1e2e16982c359128664e3785f202d3eca9b22dd0b2f91c4b3d242f/rignore-0.7.6-cp312-cp312-win32.whl", hash = "sha256:ccca9d1a8b5234c76b71546fc3c134533b013f40495f394a65614a81f7387046", size = 646145, upload-time = "2025-11-05T21:41:51.096Z" },
-    { url = "https://files.pythonhosted.org/packages/26/87/69387fb5dd81a0f771936381431780b8cf66fcd2cfe9495e1aaf41548931/rignore-0.7.6-cp312-cp312-win_amd64.whl", hash = "sha256:c96a285e4a8bfec0652e0bfcf42b1aabcdda1e7625f5006d188e3b1c87fdb543", size = 726090, upload-time = "2025-11-05T21:41:36.485Z" },
-    { url = "https://files.pythonhosted.org/packages/24/5f/e8418108dcda8087fb198a6f81caadbcda9fd115d61154bf0df4d6d3619b/rignore-0.7.6-cp312-cp312-win_arm64.whl", hash = "sha256:a64a750e7a8277a323f01ca50b7784a764845f6cce2fe38831cb93f0508d0051", size = 656317, upload-time = "2025-11-05T21:41:25.305Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/8a/a4078f6e14932ac7edb171149c481de29969d96ddee3ece5dc4c26f9e0c3/rignore-0.7.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:2bdab1d31ec9b4fb1331980ee49ea051c0d7f7bb6baa28b3125ef03cdc48fdaf", size = 883057, upload-time = "2025-11-05T20:42:42.741Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/8f/f8daacd177db4bf7c2223bab41e630c52711f8af9ed279be2058d2fe4982/rignore-0.7.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90f0a00ce0c866c275bf888271f1dc0d2140f29b82fcf33cdbda1e1a6af01010", size = 820150, upload-time = "2025-11-05T20:42:26.545Z" },
-    { url = "https://files.pythonhosted.org/packages/36/31/b65b837e39c3f7064c426754714ac633b66b8c2290978af9d7f513e14aa9/rignore-0.7.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1ad295537041dc2ed4b540fb1a3906bd9ede6ccdad3fe79770cd89e04e3c73c", size = 897406, upload-time = "2025-11-05T20:40:53.854Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/58/1970ce006c427e202ac7c081435719a076c478f07b3a23f469227788dc23/rignore-0.7.6-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f782dbd3a65a5ac85adfff69e5c6b101285ef3f845c3a3cae56a54bebf9fe116", size = 874050, upload-time = "2025-11-05T20:41:08.922Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/00/eb45db9f90137329072a732273be0d383cb7d7f50ddc8e0bceea34c1dfdf/rignore-0.7.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65cece3b36e5b0826d946494734c0e6aaf5a0337e18ff55b071438efe13d559e", size = 1167835, upload-time = "2025-11-05T20:41:24.997Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f1/6f1d72ddca41a64eed569680587a1236633587cc9f78136477ae69e2c88a/rignore-0.7.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7e4bb66c13cd7602dc8931822c02dfbbd5252015c750ac5d6152b186f0a8be0", size = 941945, upload-time = "2025-11-05T20:41:40.628Z" },
-    { url = "https://files.pythonhosted.org/packages/48/6f/2f178af1c1a276a065f563ec1e11e7a9e23d4996fd0465516afce4b5c636/rignore-0.7.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:297e500c15766e196f68aaaa70e8b6db85fa23fdc075b880d8231fdfba738cd7", size = 959067, upload-time = "2025-11-05T20:42:11.09Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/db/423a81c4c1e173877c7f9b5767dcaf1ab50484a94f60a0b2ed78be3fa765/rignore-0.7.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a07084211a8d35e1a5b1d32b9661a5ed20669970b369df0cf77da3adea3405de", size = 984438, upload-time = "2025-11-05T20:41:55.443Z" },
-    { url = "https://files.pythonhosted.org/packages/31/eb/c4f92cc3f2825d501d3c46a244a671eb737fc1bcf7b05a3ecd34abb3e0d7/rignore-0.7.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:181eb2a975a22256a1441a9d2f15eb1292839ea3f05606620bd9e1938302cf79", size = 1078365, upload-time = "2025-11-05T21:40:15.148Z" },
-    { url = "https://files.pythonhosted.org/packages/26/09/99442f02794bd7441bfc8ed1c7319e890449b816a7493b2db0e30af39095/rignore-0.7.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7bbcdc52b5bf9f054b34ce4af5269df5d863d9c2456243338bc193c28022bd7b", size = 1139066, upload-time = "2025-11-05T21:40:32.771Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/88/bcfc21e520bba975410e9419450f4b90a2ac8236b9a80fd8130e87d098af/rignore-0.7.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f2e027a6da21a7c8c0d87553c24ca5cc4364def18d146057862c23a96546238e", size = 1118036, upload-time = "2025-11-05T21:40:49.646Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/25/d37215e4562cda5c13312636393aea0bafe38d54d4e0517520a4cc0753ec/rignore-0.7.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee4a18b82cbbc648e4aac1510066682fe62beb5dc88e2c67c53a83954e541360", size = 1127550, upload-time = "2025-11-05T21:41:07.648Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/76/a264ab38bfa1620ec12a8ff1c07778da89e16d8c0f3450b0333020d3d6dc/rignore-0.7.6-cp313-cp313-win32.whl", hash = "sha256:a7d7148b6e5e95035d4390396895adc384d37ff4e06781a36fe573bba7c283e5", size = 646097, upload-time = "2025-11-05T21:41:53.201Z" },
-    { url = "https://files.pythonhosted.org/packages/62/44/3c31b8983c29ea8832b6082ddb1d07b90379c2d993bd20fce4487b71b4f4/rignore-0.7.6-cp313-cp313-win_amd64.whl", hash = "sha256:b037c4b15a64dced08fc12310ee844ec2284c4c5c1ca77bc37d0a04f7bff386e", size = 726170, upload-time = "2025-11-05T21:41:38.131Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/41/e26a075cab83debe41a42661262f606166157df84e0e02e2d904d134c0d8/rignore-0.7.6-cp313-cp313-win_arm64.whl", hash = "sha256:e47443de9b12fe569889bdbe020abe0e0b667516ee2ab435443f6d0869bd2804", size = 656184, upload-time = "2025-11-05T21:41:27.396Z" },
-    { url = "https://files.pythonhosted.org/packages/85/12/62d690b4644c330d7ac0f739b7f078190ab4308faa909a60842d0e4af5b2/rignore-0.7.6-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3d3a523af1cd4ed2c0cba8d277a32d329b0c96ef9901fb7ca45c8cfaccf31a5", size = 887462, upload-time = "2025-11-05T20:42:50.804Z" },
-    { url = "https://files.pythonhosted.org/packages/05/bc/6528a0e97ed2bd7a7c329183367d1ffbc5b9762ae8348d88dae72cc9d1f5/rignore-0.7.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:990853566e65184a506e1e2af2d15045afad3ebaebb8859cb85b882081915110", size = 826918, upload-time = "2025-11-05T20:42:33.689Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/2c/7d7bad116e09a04e9e1688c6f891fa2d4fd33f11b69ac0bd92419ddebeae/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cab9ff2e436ce7240d7ee301c8ef806ed77c1fd6b8a8239ff65f9bbbcb5b8a3", size = 900922, upload-time = "2025-11-05T20:41:00.361Z" },
-    { url = "https://files.pythonhosted.org/packages/09/ba/e5ea89fbde8e37a90ce456e31c5e9d85512cef5ae38e0f4d2426eb776a19/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d1a6671b2082c13bfd9a5cf4ce64670f832a6d41470556112c4ab0b6519b2fc4", size = 876987, upload-time = "2025-11-05T20:41:16.219Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/fb/93d14193f0ec0c3d35b763f0a000e9780f63b2031f3d3756442c2152622d/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2468729b4c5295c199d084ab88a40afcb7c8b974276805105239c07855bbacee", size = 1171110, upload-time = "2025-11-05T20:41:32.631Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/46/08436312ff96ffa29cfa4e1a987efc37e094531db46ba5e9fda9bb792afd/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:775710777fd71e5fdf54df69cdc249996a1d6f447a2b5bfb86dbf033fddd9cf9", size = 943339, upload-time = "2025-11-05T20:41:47.128Z" },
-    { url = "https://files.pythonhosted.org/packages/34/28/3b3c51328f505cfaf7e53f408f78a1e955d561135d02f9cb0341ea99f69a/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4565407f4a77f72cf9d91469e75d15d375f755f0a01236bb8aaa176278cc7085", size = 961680, upload-time = "2025-11-05T20:42:18.061Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/9e/cbff75c8676d4f4a90bd58a1581249d255c7305141b0868f0abc0324836b/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc44c33f8fb2d5c9da748de7a6e6653a78aa740655e7409895e94a247ffa97c8", size = 987045, upload-time = "2025-11-05T20:42:02.315Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/25/d802d1d369502a7ddb8816059e7c79d2d913e17df975b863418e0aca4d8a/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8f32478f05540513c11923e8838afab9efef0131d66dca7f67f0e1bbd118af6a", size = 1080310, upload-time = "2025-11-05T21:40:23.184Z" },
-    { url = "https://files.pythonhosted.org/packages/43/f0/250b785c2e473b1ab763eaf2be820934c2a5409a722e94b279dddac21c7d/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:1b63a3dd76225ea35b01dd6596aa90b275b5d0f71d6dc28fce6dd295d98614aa", size = 1140998, upload-time = "2025-11-05T21:40:40.603Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/d6/bb42fd2a8bba6aea327962656e20621fd495523259db40cfb4c5f760f05c/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:fe6c41175c36554a4ef0994cd1b4dbd6d73156fca779066456b781707402048e", size = 1121178, upload-time = "2025-11-05T21:40:57.585Z" },
-    { url = "https://files.pythonhosted.org/packages/97/f4/aeb548374129dce3dc191a4bb598c944d9ed663f467b9af830315d86059c/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:9a0c6792406ae36f4e7664dc772da909451d46432ff8485774526232d4885063", size = 1130190, upload-time = "2025-11-05T21:41:16.403Z" },
-    { url = "https://files.pythonhosted.org/packages/82/78/a6250ff0c49a3cdb943910ada4116e708118e9b901c878cfae616c80a904/rignore-0.7.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a20b6fb61bcced9a83dfcca6599ad45182b06ba720cff7c8d891e5b78db5b65f", size = 886470, upload-time = "2025-11-05T20:42:52.314Z" },
-    { url = "https://files.pythonhosted.org/packages/35/af/c69c0c51b8f9f7914d95c4ea91c29a2ac067572048cae95dd6d2efdbe05d/rignore-0.7.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:392dcabfecbe176c9ebbcb40d85a5e86a5989559c4f988c2741da7daf1b5be25", size = 825976, upload-time = "2025-11-05T20:42:35.118Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/d2/1b264f56132264ea609d3213ab603d6a27016b19559a1a1ede1a66a03dcd/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22baa462abdc36fdd5a5e2dae423107723351b85ff093762f9261148b9d0a04a", size = 899739, upload-time = "2025-11-05T20:41:01.518Z" },
-    { url = "https://files.pythonhosted.org/packages/55/e4/b3c5dfdd8d8a10741dfe7199ef45d19a0e42d0c13aa377c83bd6caf65d90/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53fb28882d2538cb2d231972146c4927a9d9455e62b209f85d634408c4103538", size = 874843, upload-time = "2025-11-05T20:41:17.687Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/10/d6f3750233881a2a154cefc9a6a0a9b19da526b19f7f08221b552c6f827d/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87409f7eeb1103d6b77f3472a3a0d9a5953e3ae804a55080bdcb0120ee43995b", size = 1170348, upload-time = "2025-11-05T20:41:34.21Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/10/ad98ca05c9771c15af734cee18114a3c280914b6e34fde9ffea2e61e88aa/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:684014e42e4341ab3ea23a203551857fcc03a7f8ae96ca3aefb824663f55db32", size = 942315, upload-time = "2025-11-05T20:41:48.508Z" },
-    { url = "https://files.pythonhosted.org/packages/de/00/ab5c0f872acb60d534e687e629c17e0896c62da9b389c66d3aa16b817aa8/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77356ebb01ba13f8a425c3d30fcad40e57719c0e37670d022d560884a30e4767", size = 961047, upload-time = "2025-11-05T20:42:19.403Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/86/3030fdc363a8f0d1cd155b4c453d6db9bab47a24fcc64d03f61d9d78fe6a/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6cbd8a48abbd3747a6c830393cd578782fab5d43f4deea48c5f5e344b8fed2b0", size = 986090, upload-time = "2025-11-05T20:42:03.581Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b8/133aa4002cee0ebbb39362f94e4898eec7fbd09cec9fcbce1cd65b355b7f/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2673225dcec7f90497e79438c35e34638d0d0391ccea3cbb79bfb9adc0dc5bd7", size = 1079656, upload-time = "2025-11-05T21:40:24.89Z" },
-    { url = "https://files.pythonhosted.org/packages/67/56/36d5d34210e5e7dfcd134eed8335b19e80ae940ee758f493e4f2b344dd70/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:c081f17290d8a2b96052b79207622aa635686ea39d502b976836384ede3d303c", size = 1139789, upload-time = "2025-11-05T21:40:42.119Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/5b/bb4f9420802bf73678033a4a55ab1bede36ce2e9b41fec5f966d83d932b3/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:57e8327aacc27f921968cb2a174f9e47b084ce9a7dd0122c8132d22358f6bd79", size = 1120308, upload-time = "2025-11-05T21:40:59.402Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/8b/a1299085b28a2f6135e30370b126e3c5055b61908622f2488ade67641479/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d8955b57e42f2a5434670d5aa7b75eaf6e74602ccd8955dddf7045379cd762fb", size = 1129444, upload-time = "2025-11-05T21:41:17.906Z" },
 ]
 
 [[package]]
@@ -3506,19 +3016,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sentry-sdk"
-version = "2.58.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "certifi" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
-]
-
-[[package]]
 name = "setuptools"
 version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3577,15 +3074,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
     { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
-]
-
-[[package]]
-name = "shellingham"
-version = "1.5.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -3862,31 +3350,6 @@ wheels = [
 ]
 
 [[package]]
-name = "starlette"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
-]
-
-[[package]]
-name = "svcs"
-version = "25.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "attrs" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/08/e1/2d56ec21820cae24a6215dc1d6a224167b0e24368bf53166551064742e0d/svcs-25.1.0.tar.gz", hash = "sha256:64dd74d0c4e8fee79a9ac7550a9d824670b228df390ba1911614e29b59b3f2c2", size = 714086, upload-time = "2025-01-25T13:15:21.505Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/1c/a6b5d90a9ca479805798276728ccbbdff0c7228e2ea93b1f731779d635e3/svcs-25.1.0-py3-none-any.whl", hash = "sha256:df49cb7d1a05dfd2dd60af1a2cb84b9c3bb0a74728833cb8c54a7ceeecce6c97", size = 19456, upload-time = "2025-01-25T13:15:19.677Z" },
-]
-
-[[package]]
 name = "tables"
 version = "3.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4022,21 +3485,6 @@ wheels = [
 ]
 
 [[package]]
-name = "typer"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "annotated-doc" },
-    { name = "click" },
-    { name = "rich" },
-    { name = "shellingham" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4073,193 +3521,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
-]
-
-[[package]]
-name = "uvicorn"
-version = "0.46.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
-]
-
-[package.optional-dependencies]
-standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
-]
-
-[[package]]
-name = "uvloop"
-version = "0.22.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
-    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
-    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
-    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
-    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
-    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
-    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
-    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
-    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
-    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
-]
-
-[[package]]
-name = "watchfiles"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
-    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
-    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
-    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
-    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
-    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
-    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
-    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
-    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
-    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
-    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
-    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
-    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
-    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
-    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
-    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
-    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
-    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
-    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
-    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
-    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
-    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
-]
-
-[[package]]
-name = "websockets"
-version = "16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
-    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
-    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
-    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
-    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
-    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
-    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
-    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
-    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
-    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
-    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
-    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
-    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
-    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
-    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
-    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
-    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1563,6 +1563,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "movici-data-core", extra = ["sqlite"] },
     { name = "movici-simulation-core", extra = ["all"] },
     { name = "mypy" },
     { name = "pytest" },
@@ -1590,6 +1591,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage" },
+    { name = "movici-data-core", extras = ["sqlite"], editable = "packages/data-core" },
     { name = "movici-simulation-core", extras = ["all"], editable = "packages/simulation-core" },
     { name = "mypy" },
     { name = "pytest" },
@@ -1618,16 +1620,19 @@ dependencies = [
     { name = "svcs" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "pytest-asyncio" },
-]
+[package.optional-dependencies]
 sqlite = [
     { name = "aiosqlite" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", marker = "extra == 'sqlite'", specifier = ">=0.22.1" },
     { name = "fastapi", extras = ["standard"] },
     { name = "marshmallow", specifier = ">=4.3.0" },
     { name = "movici-simulation-core", editable = "packages/simulation-core" },
@@ -1636,10 +1641,10 @@ requires-dist = [
     { name = "sqlalchemy" },
     { name = "svcs" },
 ]
+provides-extras = ["sqlite"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest-asyncio", specifier = ">=1.3.0" }]
-sqlite = [{ name = "aiosqlite", specifier = ">=0.22.1" }]
 
 [[package]]
 name = "movici-drinking-water-model"

--- a/uv.lock
+++ b/uv.lock
@@ -2,10 +2,14 @@ version = 1
 revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -17,6 +21,7 @@ resolution-markers = [
 [manifest]
 members = [
     "movici",
+    "movici-data-core",
     "movici-drinking-water-model",
     "movici-simulation-core",
     "movici-transport-assignment-model",
@@ -73,6 +78,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
 name = "alabaster"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -82,12 +96,35 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -106,6 +143,49 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "backports-datetime-fromisoformat"
+version = "2.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/71/81/eff3184acb1d9dc3ce95a98b6f3c81a49b4be296e664db8e1c2eeabef3d9/backports_datetime_fromisoformat-2.0.3.tar.gz", hash = "sha256:b58edc8f517b66b397abc250ecc737969486703a66eb97e01e6d51291b1a139d", size = 23588, upload-time = "2024-12-28T20:18:15.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/4b/d6b051ca4b3d76f23c2c436a9669f3be616b8cf6461a7e8061c7c4269642/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5f681f638f10588fa3c101ee9ae2b63d3734713202ddfcfb6ec6cea0778a29d4", size = 27561, upload-time = "2024-12-28T20:16:47.974Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/40/e39b0d471e55eb1b5c7c81edab605c02f71c786d59fb875f0a6f23318747/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:cd681460e9142f1249408e5aee6d178c6d89b49e06d44913c8fdfb6defda8d1c", size = 34448, upload-time = "2024-12-28T20:16:50.712Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/28/7a5c87c5561d14f1c9af979231fdf85d8f9fad7a95ff94e56d2205e2520a/backports_datetime_fromisoformat-2.0.3-cp310-cp310-macosx_11_0_x86_64.whl", hash = "sha256:ee68bc8735ae5058695b76d3bb2aee1d137c052a11c8303f1e966aa23b72b65b", size = 27093, upload-time = "2024-12-28T20:16:52.994Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ba/f00296c5c4536967c7d1136107fdb91c48404fe769a4a6fd5ab045629af8/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8273fe7932db65d952a43e238318966eab9e49e8dd546550a41df12175cc2be4", size = 52836, upload-time = "2024-12-28T20:16:55.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/92/bb1da57a069ddd601aee352a87262c7ae93467e66721d5762f59df5021a6/backports_datetime_fromisoformat-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39d57ea50aa5a524bb239688adc1d1d824c31b6094ebd39aa164d6cadb85de22", size = 52798, upload-time = "2024-12-28T20:16:56.64Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ef/b6cfd355982e817ccdb8d8d109f720cab6e06f900784b034b30efa8fa832/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ac6272f87693e78209dc72e84cf9ab58052027733cd0721c55356d3c881791cf", size = 52891, upload-time = "2024-12-28T20:16:58.887Z" },
+    { url = "https://files.pythonhosted.org/packages/37/39/b13e3ae8a7c5d88b68a6e9248ffe7066534b0cfe504bf521963e61b6282d/backports_datetime_fromisoformat-2.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:44c497a71f80cd2bcfc26faae8857cf8e79388e3d5fbf79d2354b8c360547d58", size = 52955, upload-time = "2024-12-28T20:17:00.028Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/e4/70cffa3ce1eb4f2ff0c0d6f5d56285aacead6bd3879b27a2ba57ab261172/backports_datetime_fromisoformat-2.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:6335a4c9e8af329cb1ded5ab41a666e1448116161905a94e054f205aa6d263bc", size = 29323, upload-time = "2024-12-28T20:17:01.125Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f5/5bc92030deadf34c365d908d4533709341fb05d0082db318774fdf1b2bcb/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e2e4b66e017253cdbe5a1de49e0eecff3f66cd72bcb1229d7db6e6b1832c0443", size = 27626, upload-time = "2024-12-28T20:17:03.448Z" },
+    { url = "https://files.pythonhosted.org/packages/28/45/5885737d51f81dfcd0911dd5c16b510b249d4c4cf6f4a991176e0358a42a/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:43e2d648e150777e13bbc2549cc960373e37bf65bd8a5d2e0cef40e16e5d8dd0", size = 34588, upload-time = "2024-12-28T20:17:04.459Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6d/bd74de70953f5dd3e768c8fc774af942af0ce9f211e7c38dd478fa7ea910/backports_datetime_fromisoformat-2.0.3-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:4ce6326fd86d5bae37813c7bf1543bae9e4c215ec6f5afe4c518be2635e2e005", size = 27162, upload-time = "2024-12-28T20:17:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ba/1d14b097f13cce45b2b35db9898957578b7fcc984e79af3b35189e0d332f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7c8fac333bf860208fd522a5394369ee3c790d0aa4311f515fcc4b6c5ef8d75", size = 54482, upload-time = "2024-12-28T20:17:08.15Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e9/a2a7927d053b6fa148b64b5e13ca741ca254c13edca99d8251e9a8a09cfe/backports_datetime_fromisoformat-2.0.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24a4da5ab3aa0cc293dc0662a0c6d1da1a011dc1edcbc3122a288cfed13a0b45", size = 54362, upload-time = "2024-12-28T20:17:10.605Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/99/394fb5e80131a7d58c49b89e78a61733a9994885804a0bb582416dd10c6f/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58ea11e3bf912bd0a36b0519eae2c5b560b3cb972ea756e66b73fb9be460af01", size = 54162, upload-time = "2024-12-28T20:17:12.301Z" },
+    { url = "https://files.pythonhosted.org/packages/88/25/1940369de573c752889646d70b3fe8645e77b9e17984e72a554b9b51ffc4/backports_datetime_fromisoformat-2.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:8a375c7dbee4734318714a799b6c697223e4bbb57232af37fbfff88fb48a14c6", size = 54118, upload-time = "2024-12-28T20:17:13.609Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/46/f275bf6c61683414acaf42b2df7286d68cfef03e98b45c168323d7707778/backports_datetime_fromisoformat-2.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:ac677b1664c4585c2e014739f6678137c8336815406052349c85898206ec7061", size = 29329, upload-time = "2024-12-28T20:17:16.124Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/0f/69bbdde2e1e57c09b5f01788804c50e68b29890aada999f2b1a40519def9/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:66ce47ee1ba91e146149cf40565c3d750ea1be94faf660ca733d8601e0848147", size = 27630, upload-time = "2024-12-28T20:17:19.442Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1d/1c84a50c673c87518b1adfeafcfd149991ed1f7aedc45d6e5eac2f7d19d7/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:8b7e069910a66b3bba61df35b5f879e5253ff0821a70375b9daf06444d046fa4", size = 34707, upload-time = "2024-12-28T20:17:21.79Z" },
+    { url = "https://files.pythonhosted.org/packages/71/44/27eae384e7e045cda83f70b551d04b4a0b294f9822d32dea1cbf1592de59/backports_datetime_fromisoformat-2.0.3-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:a3b5d1d04a9e0f7b15aa1e647c750631a873b298cdd1255687bb68779fe8eb35", size = 27280, upload-time = "2024-12-28T20:17:24.503Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7a/a4075187eb6bbb1ff6beb7229db5f66d1070e6968abeb61e056fa51afa5e/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ec1b95986430e789c076610aea704db20874f0781b8624f648ca9fb6ef67c6e1", size = 55094, upload-time = "2024-12-28T20:17:25.546Z" },
+    { url = "https://files.pythonhosted.org/packages/71/03/3fced4230c10af14aacadc195fe58e2ced91d011217b450c2e16a09a98c8/backports_datetime_fromisoformat-2.0.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe5f793db59e2f1d45ec35a1cf51404fdd69df9f6952a0c87c3060af4c00e32", size = 55605, upload-time = "2024-12-28T20:17:29.208Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/0a/4b34a838c57bd16d3e5861ab963845e73a1041034651f7459e9935289cfd/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:620e8e73bd2595dfff1b4d256a12b67fce90ece3de87b38e1dde46b910f46f4d", size = 55353, upload-time = "2024-12-28T20:17:32.433Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/68/07d13c6e98e1cad85606a876367ede2de46af859833a1da12c413c201d78/backports_datetime_fromisoformat-2.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4cf9c0a985d68476c1cabd6385c691201dda2337d7453fb4da9679ce9f23f4e7", size = 55298, upload-time = "2024-12-28T20:17:34.919Z" },
+    { url = "https://files.pythonhosted.org/packages/60/33/45b4d5311f42360f9b900dea53ab2bb20a3d61d7f9b7c37ddfcb3962f86f/backports_datetime_fromisoformat-2.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:d144868a73002e6e2e6fef72333e7b0129cecdd121aa8f1edba7107fd067255d", size = 29375, upload-time = "2024-12-28T20:17:36.018Z" },
+    { url = "https://files.pythonhosted.org/packages/be/03/7eaa9f9bf290395d57fd30d7f1f2f9dff60c06a31c237dc2beb477e8f899/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90e202e72a3d5aae673fcc8c9a4267d56b2f532beeb9173361293625fe4d2039", size = 28980, upload-time = "2024-12-28T20:18:06.554Z" },
+    { url = "https://files.pythonhosted.org/packages/47/80/a0ecf33446c7349e79f54cc532933780341d20cff0ee12b5bfdcaa47067e/backports_datetime_fromisoformat-2.0.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2df98ef1b76f5a58bb493dda552259ba60c3a37557d848e039524203951c9f06", size = 28449, upload-time = "2024-12-28T20:18:07.77Z" },
 ]
 
 [[package]]
@@ -459,10 +539,14 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -617,6 +701,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -634,10 +727,14 @@ name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -646,6 +743,19 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -658,6 +768,159 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "email-validator" },
+    { name = "fastapi-cli", extra = ["standard"] },
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "jinja2" },
+    { name = "pydantic-extra-types" },
+    { name = "pydantic-settings" },
+    { name = "python-multipart" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "fastapi-cli"
+version = "0.0.24"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "rich-toolkit" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/58/74797ae9e4610cfa0c6b34c8309096d3b20bb29be3b8b5fbf1004d10fa5f/fastapi_cli-0.0.24.tar.gz", hash = "sha256:1afc9c9e21d7ebc8a3ca5e31790cd8d837742be7e4f8b9236e99cb3451f0de00", size = 19043, upload-time = "2026-02-24T10:45:10.476Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/4b/68f9fe268e535d79c76910519530026a4f994ce07189ac0dded45c6af825/fastapi_cli-0.0.24-py3-none-any.whl", hash = "sha256:4a1f78ed798f106b4fee85ca93b85d8fe33c0a3570f775964d37edb80b8f0edc", size = 12304, upload-time = "2026-02-24T10:45:09.552Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "fastapi-cloud-cli" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[[package]]
+name = "fastapi-cloud-cli"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastar" },
+    { name = "httpx" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "rich-toolkit" },
+    { name = "rignore" },
+    { name = "sentry-sdk" },
+    { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/96/57/cee8e91b83f39e75ae5562a2237261442a8179dcb3b631c7398113157398/fastapi_cloud_cli-0.17.1.tar.gz", hash = "sha256:0baece208fa88063bec46dccb5fb512f3199162092165e57654b44e64adbc44d", size = 47409, upload-time = "2026-04-27T13:38:07.094Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/a0/e252b68cf155409afabea037ab2971f41509481838847f6503fe890884ea/fastapi_cloud_cli-0.17.1-py3-none-any.whl", hash = "sha256:325e0199bdac7cb86f5df4f4a1d2070054095588088ef7b923a60cec458dcd63", size = 34046, upload-time = "2026-04-27T13:38:08.319Z" },
+]
+
+[[package]]
+name = "fastar"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/0f/0aeb3fc50046617702acc0078b277b58367fd62eb727b9ec733ae0e8bbcc/fastar-0.11.0.tar.gz", hash = "sha256:aa7f100f7313c03fdb20f1385927ba95671071ba308ad0c1763fef295e1895ce", size = 70238, upload-time = "2026-04-13T17:11:17.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/4a/0d79fe52243a4130aa41d0a3a9eea22e00427db761e1a6782ee817c50222/fastar-0.11.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:e7c906ad371ca365591ebcb7630009923f3eceb20956814494d15591a78e9e46", size = 709786, upload-time = "2026-04-13T17:09:53.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e4/77c94eaafc035e39f5ce5176e32743da4e3fe890f28790e708e53d8f75cd/fastar-0.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6919497b35fa5bd978d2c26ee117cf1771b90ee5073f7518e44b9bc364b57715", size = 632127, upload-time = "2026-04-13T17:09:39.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f6/97658dd992f4e45747d35adb24c0b100f6b6d451490685ae3fe8a3a2ee1b/fastar-0.11.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:56b50206aeedd99e22b83289e6fb3ff8f7d7da4407d2419902e4716b4f90585a", size = 869608, upload-time = "2026-04-13T17:09:08.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/fc/81c1ec4d8146a437399e7b95631b51be312f323a9ce64569f932db6c3914/fastar-0.11.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a1811a69ae81d469720df0c8af3f84f834a93b5e4f8be0e0e8bde6a52fa11f2", size = 762925, upload-time = "2026-04-13T17:07:52.788Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/35/49baf480ecb197aea7ce2515c503a2f25061958dd3b4c98e98a3a11cdcc7/fastar-0.11.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10486238c55589a3947c38f9cfb88a67d8a608eb8dddc722038237d0278a41d7", size = 759913, upload-time = "2026-04-13T17:08:07.324Z" },
+    { url = "https://files.pythonhosted.org/packages/94/eb/946f1980267f2824efb7d7c518d47a49b89c0e9cd7c449301f5a7531558a/fastar-0.11.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1555ef9992d368a6ec39092276990cef8d329c39a1d86ebd847eaa3b10efd472", size = 926054, upload-time = "2026-04-13T17:08:22.196Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/19/d5eb611085ce054382570d8d4e24a5e2ff23cd6d2404528a6643841d6059/fastar-0.11.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b1f4aca0a9620b76988bbf6225cdea6678a392902444ca18bb8a51495b165a89", size = 818594, upload-time = "2026-04-13T17:08:52.366Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/52/18e8d55c0d3d917713f381cb2d0cb793da00c209c802e011d8dc72018cd5/fastar-0.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75beeecac7d11a666a6c4a0b7f7e80842ae5cf523f2f890b99c78fc82b403545", size = 823005, upload-time = "2026-04-13T17:09:23.051Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b4/0fecdcf33e5aaffe777b96a1c10a3204fe0b05bf18e971033a0bfedafc1c/fastar-0.11.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a08cdf5d16daa401c65c9c7493a18db7dc515c52155a17071ec7098bb07da9d3", size = 887115, upload-time = "2026-04-13T17:08:37.385Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f8/2a6ad1c2523eb72a4595a9331162fc67ce0f0aee3348728598026c516986/fastar-0.11.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6e210375e5a7ba53586cbd6017aa417d2d2ceacbe8671682470281bd0a15e8ef", size = 973595, upload-time = "2026-04-13T17:10:09.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/a6/2aa48843228673feacc2b80876b8924e63ea9c5f5f607bd7a72416b86bae/fastar-0.11.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a2988eb2604b8e15670f355425e8c800e4dcd4edfbcbfe194397f8f17b7eb19e", size = 1036988, upload-time = "2026-04-13T17:10:26.133Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ac/3dd14b21c323e8484f47c910110d1d93139ba44621ac2c4c597dbe9fcdb7/fastar-0.11.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:34abc857b46068fdf91d157bd0203bfd6791dc7a432d1ed180f5af6c2f5bcce9", size = 1078267, upload-time = "2026-04-13T17:10:43.645Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a1/3f89e58d6fa99160c9e7e17220c8ab5040b5cc017c4fac2356c6ed18453d/fastar-0.11.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:0d884be84e37a01053776395441fc960031974e0265801ce574efc3d05e0cdaf", size = 1032551, upload-time = "2026-04-13T17:11:00.667Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ea/24dd3cfc2096933d7d2a80c926e79602cff1fa481124ed2165b60c1dd9ef/fastar-0.11.0-cp310-cp310-win32.whl", hash = "sha256:c721c1ad758e3e4c2c1fd9e96911a0fa58c0a6be5668f1bcfd0b741e72c7cb63", size = 456022, upload-time = "2026-04-13T17:11:41.859Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ef/6eb39ee9cdd59822d1c7337c4d28fdc948885bdf455af9e70efa9879e06f/fastar-0.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:ba4180b7c3080f55f9035fdd7d8c39fe0e1485087a68ff615bb4784a10b8106b", size = 488392, upload-time = "2026-04-13T17:11:27.486Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7a/fb367bdaf4efa2c7952a45aeab2e87a564293ecffe150af673ec8edfda46/fastar-0.11.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:b82fd6f996e65a86f67a6bd64dd22ef3e8ae2dcaed0ae3b550e71f7e1bbb1df5", size = 709869, upload-time = "2026-04-13T17:09:55.62Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ff/b87efb0dcfd081c62c7c7601d7681dabe63103cd51fc16f8d57a1ab45961/fastar-0.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:27eed386fd0558e6daa29211111bbd7b740f7c7e881197f8a00ac7c0f3cdb1d7", size = 631668, upload-time = "2026-04-13T17:09:40.537Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7c/0ed6dd38b9adc04b3a8ec3b7045908e7c2170ba0ff6e6d2c51bc9fc770f3/fastar-0.11.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a6931bebc1d8e95ddeef55732c195449e6b44ef33aa31b325505097ed3b4d6aa", size = 869663, upload-time = "2026-04-13T17:09:09.78Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ce/8b7fb3f23855accebaaf2d2637eac7f261a7a5d936f861a172079f1ef511/fastar-0.11.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:891f72ce42a5e28a74fbd4d5fbf1a3ac1a1163d13cbc200cbd005fb0fabc54bd", size = 762938, upload-time = "2026-04-13T17:07:54.51Z" },
+    { url = "https://files.pythonhosted.org/packages/07/cc/5491e2b677bb841f768e3aba052d0344338a5c78aa5d4c18b443831a8e8d/fastar-0.11.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5b83c1f61f7017d6e1498568038f8745440cfc16ca2f697ec81bac83050108f6", size = 759232, upload-time = "2026-04-13T17:08:08.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b7/643630bdbd179e41e9fae31c03b4cf6061dbf4d6fbbae8425d16eb12545d/fastar-0.11.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:db73a9b765a516e73983b25341e7b5e0189733878279e278b2295131b0e3a21e", size = 926271, upload-time = "2026-04-13T17:08:23.68Z" },
+    { url = "https://files.pythonhosted.org/packages/09/5d/37ade50003b4540e0a53ef100f6692d7ab2ac1122d5acf39920cc09a3e8b/fastar-0.11.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:625827d52eb4e8fec942e0233f125ff8010fcf6a67c0a974a8e5f4666b771e3c", size = 818634, upload-time = "2026-04-13T17:08:54.268Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ff/135d177de32cc1e837c99019e4643e6e79352bde49544d4ece5b5eebf56b/fastar-0.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d7f5fd8fa21ec0a88296a38dc5d7fc35efd3b26d46a17b8b7c73c5563925ca15", size = 822755, upload-time = "2026-04-13T17:09:25.01Z" },
+    { url = "https://files.pythonhosted.org/packages/27/cb/b835dbe76ceac7fa6105851468c259ffd06830eb9c029402e499d0ec153b/fastar-0.11.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:8c15af91b8cd87ddf23ea55355ae513c1de3ab67178f26dad017c9e9c0af6096", size = 887101, upload-time = "2026-04-13T17:08:39.248Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/54/aa8289eb57fc550535470397cb051f5a58a7c89ca4de31d5502b916dd894/fastar-0.11.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:03a112395a8b0bff251423bd1564c012f0cc058ad8b6bd8fba96f3d7fc117e44", size = 973606, upload-time = "2026-04-13T17:10:10.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/fd/776d50a0897c01dc6bfd0926772ee913436fdae91b9affaf0a0cbd09f0a1/fastar-0.11.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f2994bb8f5f8c11eb12beae1e6e77a907173c9819236b8a4c8f0573652ceccce", size = 1036696, upload-time = "2026-04-13T17:10:28.502Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f1/cf0f9b499fb37ac065c8a01ec642f96a3c5eb849c38ae983b59f3b3245e0/fastar-0.11.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dcf99e4b5973d842c7f19c776c3a83cdc0977d505edce6206438505c0456b517", size = 1078182, upload-time = "2026-04-13T17:10:45.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9e/21e4701aec4a1123d4dc4d31578dc18875582b5710e4725f7ceb752a248b/fastar-0.11.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:29c9c386dc0d5dda78845a8e6b1480d26ab861c1e0b68f42ae5735cb70ca07f1", size = 1032336, upload-time = "2026-04-13T17:11:02.364Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/5872b28c72c27ec1a00760eace6ff35f714f41ebbd5208cf016b12e29250/fastar-0.11.0-cp311-cp311-win32.whl", hash = "sha256:030b2580fc394f2c9b7890b6735810404e9b9ed5e0344db150b945965b5482b7", size = 457368, upload-time = "2026-04-13T17:11:43.528Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6e/ce6832a16193eb4466f4108be8809c249b51cb1f89dd7894545700d079d5/fastar-0.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:83ab57ae067969cd0b483ac3b6dccc4b595fc77f5c820760998648d4c42822b5", size = 488605, upload-time = "2026-04-13T17:11:29.161Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5a/9cfb80661cf38fd7b0889224beb7d2746784d4ade2a931ed9775a18d8602/fastar-0.11.0-cp311-cp311-win_arm64.whl", hash = "sha256:27b1a4cee2298b704de8151d310462ee7335ed036011ca9aa6e784b30b6c73a9", size = 464580, upload-time = "2026-04-13T17:11:18.583Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/06/a5773706afc8bd496769786590bbc56d2d0ee419a299cc12ea3f5717fcf3/fastar-0.11.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3c51f1c2cdddbd1420d2897ace7738e36c65e17f6ae84e0bfe763f8d1068bb97", size = 708394, upload-time = "2026-04-13T17:09:57.269Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/d5e2a4e48495616440a21eed07558219ca90243ad00b0502586f95bd4833/fastar-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0d9d6b052baf5380baea866675dab6ccd04ec2460d12b1c46f10ce3f4ee6a820", size = 628417, upload-time = "2026-04-13T17:09:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/69/9816d69ac8265c9e50456637a487ccfb7a9c566efd9dbcd673df9c2558c2/fastar-0.11.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd2f05666d4df7e14885b5c38fefd92a785917387513d33d837ff42ec143a22f", size = 863950, upload-time = "2026-04-13T17:09:11.506Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0d/f88daad53aff2e754b6b5ff2a7113f72447a34f6ef17cc23ca99988117b7/fastar-0.11.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e6e74aba1ae77ca4aedcaf1697cd413319f4c88a5ccbe5b42c709517c5097e", size = 760737, upload-time = "2026-04-13T17:07:55.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/a6/82ef4ecd969d50d92ed3ed9dbd8fe77faa24be5e5736f716edc9f4ce8d62/fastar-0.11.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:38ef77fe940bbc9b37a98bd838727f844b11731cd39358a2640ff864fb385086", size = 757603, upload-time = "2026-04-13T17:08:10.623Z" },
+    { url = "https://files.pythonhosted.org/packages/03/35/50249f0d827251f8ac511495e2eacccebda80a00a0ad73e9615b8113b84f/fastar-0.11.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8955e61b32d6aff82c983217abf80933fd823b0e727586fc72f08043d996fd59", size = 923952, upload-time = "2026-04-13T17:08:25.526Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d8/faee41659e9c379d906d24eaee6d6833ac8cfef0a5df480e5c2a8d3efb33/fastar-0.11.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:483532442cdb08fbff0169510224eae0836f2f672cea6aacb52847d90fefdc46", size = 816574, upload-time = "2026-04-13T17:08:56.076Z" },
+    { url = "https://files.pythonhosted.org/packages/22/47/0448ea7992b997dad2bf004bfd98eca74b5858630eae080b50c7b17d9ddc/fastar-0.11.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef5a6071121e05d8287fc75bccb054bcbac8bb0501200a0c0a8feeace5303ea4", size = 819382, upload-time = "2026-04-13T17:09:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ef/0d63eb43586831b7a6f8b22c4d77125a7c594423af1f4f090fa9541b9b40/fastar-0.11.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:e45e598af5afe8412197d4786efd6cf29be02e7d3d4f6a3461149eae5d7e94f1", size = 885254, upload-time = "2026-04-13T17:08:40.9Z" },
+    { url = "https://files.pythonhosted.org/packages/01/25/edd584675d69e49a165052c3ee886df1c5d574f3e7d813c990306387c623/fastar-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2e160919b1c47ddb8538e7e8eb4cd527281b40f0bf75110a75993838ef61f286", size = 971239, upload-time = "2026-04-13T17:10:12.997Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/37/e8bb24f506ba2b08fbaf36c5800e843bd4d542954e9331f00418e2d23349/fastar-0.11.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4bb4dc0fc8f7a6807febcebce8a2f3626ba4955a9263d81ecc630aad83be84c0", size = 1035185, upload-time = "2026-04-13T17:10:30.207Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bf/be753736296338149ee4cb3e92e2b5423d6ba17c7b951d15218fd7e99bbf/fastar-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4ec95af56aa173f6e320e1183001bf108ba59beaf13edd1fc8200648db203588", size = 1072191, upload-time = "2026-04-13T17:10:47.072Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/cd/a81c1aaafb5a22ce57c98ae22f39c89413ed53e4ee6e1b1444b0bd666a6c/fastar-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:136cf342735464091c39dc3708168f9fdeb9ebea40b1ead937c61afaf46143d9", size = 1028054, upload-time = "2026-04-13T17:11:04.293Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/88/1ce4eed3d70627c95f49ca017f6bbbf2ddcc4b0c601d293259de7689bc20/fastar-0.11.0-cp312-cp312-win32.whl", hash = "sha256:35f23c11b556cc4d3704587faacbc0037f7bdf6c4525cd1d09c70bda4b1c6809", size = 454198, upload-time = "2026-04-13T17:11:45.168Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1d/26ce92f4331cd61a69840db9ca6115829805eec24f285481a854f578e917/fastar-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:920bc56c3c0b8a8ca492904941d1883c1c947c858cd93343356c29122a38f44c", size = 486697, upload-time = "2026-04-13T17:11:31.084Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/96/e6eda4480559c69b05d466e7b5ea9170e81fef3795a73e059959a3258319/fastar-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:395248faf89e8a6bd5dc1fd544c8465113b627cb6d7c8b296796b60ebea33593", size = 462591, upload-time = "2026-04-13T17:11:20.577Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d6/3be260037e86fb694e88d47f583bac3a0188c99cee1a6b257ac26cb6b53c/fastar-0.11.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:33f544b08b4541b678e53749b4552a44720d96761fb79c172b005b1089c443ed", size = 707975, upload-time = "2026-04-13T17:09:58.866Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/cd/7867aefb1784662554a335f2952c75a50f0c70585ed0d2210d6cc15e5627/fastar-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c1c792447e4a642745f347ff9847c52af39633071c57ee67ed53c157fc3506", size = 628460, upload-time = "2026-04-13T17:09:43.776Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2b/d11d84bdd5e0e377771b955755771e3460b290da5809cb78c1b735ee2228/fastar-0.11.0-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:881247e6b6eaea59fc6569f9b61447aa6b9fc2ee864e048b4643d69c52745805", size = 863054, upload-time = "2026-04-13T17:09:13.048Z" },
+    { url = "https://files.pythonhosted.org/packages/25/39/d3f428b318fa940b1b6e785b8d54fc895dfb5d5b945ef8d5442ffa904fb2/fastar-0.11.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:863b7929845c9fec92ef6c8d59579cf46af5136655e5342f8df5cebe46cab06c", size = 760247, upload-time = "2026-04-13T17:07:57.396Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/04/03949aee82aabb8ede06ac5a4a5579ffaf98a8fe59ce958494508ff15513/fastar-0.11.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:96b4a57df12bf3211662627a3ea29d62ecb314a2434a0d0843f9fc23e47536e5", size = 756512, upload-time = "2026-04-13T17:08:12.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/0c/2ca1ae0a3828ca51047962d932b80daca2522db73e8cb9d040cb6ebe28d5/fastar-0.11.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ceef1c2c4df7b7b8ebd3f5d718bbf457b9bbdf25ce0bd07870211ec4fbd9aff4", size = 922183, upload-time = "2026-04-13T17:08:27.187Z" },
+    { url = "https://files.pythonhosted.org/packages/65/68/7fe808b1f73a68e686f25434f538c6dc10ef4dfb3db0ace22cd861744bf8/fastar-0.11.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8e545918441910a779659d4759ad0eef349e935fbdb4668a666d3681567eb05", size = 816394, upload-time = "2026-04-13T17:08:57.657Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/17/07d086080f8a83b8d7966955e29bcdbd6a060f5bd949dc9d5abd3658cead/fastar-0.11.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28095bb8f821e85fc2764e1a55f03e5e2876dee2abe7cd0ee9420d929905d643", size = 818983, upload-time = "2026-04-13T17:09:28.46Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/2c4edf0910af2e814ff6d65b77a91196d472ca8a9fb2033bd983f6856caa/fastar-0.11.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0fafb95ecbe70f666a5e9b35dd63974ccdc9bb3d99ccdbd4014a823ec3e659b5", size = 884689, upload-time = "2026-04-13T17:08:42.763Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/04fdcbd6558e60de4ced3b55230fac47675d181252582b2fcec3c74608e5/fastar-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:af48fed039b94016629dcdad1c95c90c486326dd068de2b0a4df419ee09b6821", size = 970677, upload-time = "2026-04-13T17:10:15.124Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b3/2b860a9658550167dbd5824c85e88d0b4b912bf493e42a6322544d6e483d/fastar-0.11.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:74cd96163f39b8638ab4e8d49708ca887959672a22871d8170d01f067319533b", size = 1034026, upload-time = "2026-04-13T17:10:32.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/9b/fa42ea1188b144bac4b1b60753dfd449974a4d5eda132029ee7711569f94/fastar-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4e8b993cb5613bab495ed482810bedc0986633fcb9a3b55c37ec88e0d6714f6a", size = 1071147, upload-time = "2026-04-13T17:10:48.833Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c8/d2e501556dca9f1fbc9246111a31792fb49ad908fa4927f34938a97a3604/fastar-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfe39d91fc28e37e06162d94afe01050220edb7df554acb5b702b5503e564816", size = 1028377, upload-time = "2026-04-13T17:11:06.374Z" },
+    { url = "https://files.pythonhosted.org/packages/db/33/5f11f23eca0a569cd052507bc45dda2e5468697f8665728d25be44120f7d/fastar-0.11.0-cp313-cp313-win32.whl", hash = "sha256:c5f63d4d99ff4bfb37c659982ec413358bdee747005348756cc50a04d412d989", size = 454089, upload-time = "2026-04-13T17:11:46.821Z" },
+    { url = "https://files.pythonhosted.org/packages/da/2f/35ff03c939cba7a255a9132367873fec6c355fd06a7f84fedcbaf4c8129f/fastar-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8690ed1928d31ded3ada308e1086525fb3871f5fa81e1b69601a3f7774004583", size = 486312, upload-time = "2026-04-13T17:11:32.86Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/ee9246cbfcbfd4144558f35e7e9a306ffe0a7564730a5188c45f21d2dab8/fastar-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:d977ded9d98a0719a305e0a4d5ee811f1d3e856d853a50acb8ae833c3cd6d5d2", size = 461975, upload-time = "2026-04-13T17:11:22.589Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/5c/9bbeffbf1905391446dd98aa520422ce7affde5c9a7c22d757cc5d7c1397/fastar-0.11.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:1266d6a004f427b0d61bd6c7b544d84cc964691b2232c2f4d635a1b75f2f6d5e", size = 711644, upload-time = "2026-04-13T17:10:07.663Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/af/ae5cf39d4fb82d0c592705f5ec6db1b065be5265c151b108f86126ee8773/fastar-0.11.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:298a827ec04ade43733f6ca960d0faec38706aa1494175869ea7ea17f5bad5d3", size = 634371, upload-time = "2026-04-13T17:09:52.083Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/36/8d4569e26473c72ccb02d1c5df3ed710073f1c06eca09c26d52ea79fd815/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8800e2387e463a0e5799416a1cbe72dd0fde7270a20e4bde684145e7878f6516", size = 870850, upload-time = "2026-04-13T17:09:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/46/724dc796e1756d3977970f820d30d59bb8cab8e3671b285f1d82ab513aec/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7496def0a2befd82d429cb004ef7ca831585cc887947bd6b9abb68a5ef852b0b", size = 764469, upload-time = "2026-04-13T17:08:05.638Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e3/74d6859e632e8fb9339a14f652fb9f800c2bd6aa53071e311c0be3fbab8b/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:878eaf15463eb572e3538af7ca3a8534e5e279cf8196db902d24e5725c4af86e", size = 761375, upload-time = "2026-04-13T17:08:20.669Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/e7/cc70e2be5ef8731a7525552b1c35c1448cf9eae6a62cb3a56f12c1bf27ea/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0324ed1d1ef0186e1bbd843b17807d6d837d0906899d4c99378b02c5d86bdd9c", size = 928189, upload-time = "2026-04-13T17:08:35.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/33/c9a969e78dca323547276a6fee5f4f9588f7cd5ab45acec3778c67399589/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bdf9bd863205590beaf8ef6e66f315310196632180dceaf674985d01a876cac3", size = 820864, upload-time = "2026-04-13T17:09:06.366Z" },
+    { url = "https://files.pythonhosted.org/packages/84/bd/6b9434b541fe55c125b5f2e017a565596a2d215aa09207e4555e4585064f/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59af8dbb683b24b90fb5b506de080faeab0a17a908e6c2a5d93a97260ed75d7b", size = 824060, upload-time = "2026-04-13T17:09:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/24/8d/871d5f8cf4c6f13987119fb0a9ae8be131e34f2756c2524e9974adf33824/fastar-0.11.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:9f3df73a3c4292cfe15696cdf59cdb6c309ab59d30b34c733be13c6e32d9a264", size = 889217, upload-time = "2026-04-13T17:08:50.884Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/26/cca0fd2704f3ed20165e5613ed911549aef3aaf3b0b5b02fee0e8e23e6cc/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:aa3762cbb16e41a76b61f4a6914937a71aab3a7b6c2d82ca233bc686ebaf756b", size = 975418, upload-time = "2026-04-13T17:10:24.307Z" },
+    { url = "https://files.pythonhosted.org/packages/99/94/8bbb0b13f5b6cbe2492f0b7cbba5103e6163976a3331466d010e781fa189/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:a8c7bc8ac74cb359bb546b199288c83236372d094b402e557c197e85527495cd", size = 1038492, upload-time = "2026-04-13T17:10:41.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/d3/5b7df222a30eac2822ffd00f82fd4c2ce84fba4b369d1e1a03732fd177fc/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:587cbd060a2699c5f66281081395bb4657b2b1e0eef5c206b1aabf740019d670", size = 1080210, upload-time = "2026-04-13T17:10:58.462Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/6d/56ef943ea524784598c035ccbd42e564e937da0438ae3f55f0e76cb95571/fastar-0.11.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:6a1c56957ac82408be37a3f63594bc83e0919e8760492a4475e542f9f1828778", size = 1034886, upload-time = "2026-04-13T17:11:15.617Z" },
 ]
 
 [[package]]
@@ -811,6 +1074,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
     { url = "https://files.pythonhosted.org/packages/91/39/5ef5aa23bc545aa0d31e1b9b55822b32c8da93ba657295840b6b34124009/greenlet-3.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:a7945dd0eab63ded0a48e4dcade82939783c172290a7903ebde9e184333ca124", size = 230961, upload-time = "2026-02-20T20:16:58.461Z" },
     { url = "https://files.pythonhosted.org/packages/62/6b/a89f8456dcb06becff288f563618e9f20deed8dd29beea14f9a168aef64b/greenlet-3.3.2-cp313-cp313-win_arm64.whl", hash = "sha256:394ead29063ee3515b4e775216cb756b2e3b4a7e55ae8fd884f17fa579e6b327", size = 230221, upload-time = "2026-02-20T20:17:37.152Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e5/c07e0bcf4ec8db8164e9f6738c048b2e66aabf30e7506f440c4cc6953f60/httptools-0.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:11d01b0ff1fe02c4c32d60af61a4d613b74fad069e47e06e9067758c01e9ac78", size = 204531, upload-time = "2025-10-10T03:54:20.887Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/4f/35e3a63f863a659f92ffd92bef131f3e81cf849af26e6435b49bd9f6f751/httptools-0.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:84d86c1e5afdc479a6fdabf570be0d3eb791df0ae727e8dbc0259ed1249998d4", size = 109408, upload-time = "2025-10-10T03:54:22.455Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/71/b0a9193641d9e2471ac541d3b1b869538a5fb6419d52fd2669fa9c79e4b8/httptools-0.7.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c8c751014e13d88d2be5f5f14fc8b89612fcfa92a9cc480f2bc1598357a23a05", size = 440889, upload-time = "2025-10-10T03:54:23.753Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d9/2e34811397b76718750fea44658cb0205b84566e895192115252e008b152/httptools-0.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:654968cb6b6c77e37b832a9be3d3ecabb243bbe7a0b8f65fbc5b6b04c8fcabed", size = 440460, upload-time = "2025-10-10T03:54:25.313Z" },
+    { url = "https://files.pythonhosted.org/packages/01/3f/a04626ebeacc489866bb4d82362c0657b2262bef381d68310134be7f40bb/httptools-0.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b580968316348b474b020edf3988eecd5d6eec4634ee6561e72ae3a2a0e00a8a", size = 425267, upload-time = "2025-10-10T03:54:26.81Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/99/adcd4f66614db627b587627c8ad6f4c55f18881549bab10ecf180562e7b9/httptools-0.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:d496e2f5245319da9d764296e86c5bb6fcf0cf7a8806d3d000717a889c8c0b7b", size = 424429, upload-time = "2025-10-10T03:54:28.174Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/ec8fc904a8fd30ba022dfa85f3bbc64c3c7cd75b669e24242c0658e22f3c/httptools-0.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cbf8317bfccf0fed3b5680c559d3459cccf1abe9039bfa159e62e391c7270568", size = 86173, upload-time = "2025-10-10T03:54:29.5Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/08/17e07e8d89ab8f343c134616d72eebfe03798835058e2ab579dcc8353c06/httptools-0.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:474d3b7ab469fefcca3697a10d11a32ee2b9573250206ba1e50d5980910da657", size = 206521, upload-time = "2025-10-10T03:54:31.002Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/06/c9c1b41ff52f16aee526fd10fbda99fa4787938aa776858ddc4a1ea825ec/httptools-0.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3c3b7366bb6c7b96bd72d0dbe7f7d5eead261361f013be5f6d9590465ea1c70", size = 110375, upload-time = "2025-10-10T03:54:31.941Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/10935db22fda0ee34c76f047590ca0a8bd9de531406a3ccb10a90e12ea21/httptools-0.7.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:379b479408b8747f47f3b253326183d7c009a3936518cdb70db58cffd369d9df", size = 456621, upload-time = "2025-10-10T03:54:33.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/84/875382b10d271b0c11aa5d414b44f92f8dd53e9b658aec338a79164fa548/httptools-0.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cad6b591a682dcc6cf1397c3900527f9affef1e55a06c4547264796bbd17cf5e", size = 454954, upload-time = "2025-10-10T03:54:34.226Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/44f89b280f7e46c0b1b2ccee5737d46b3bb13136383958f20b580a821ca0/httptools-0.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:eb844698d11433d2139bbeeb56499102143beb582bd6c194e3ba69c22f25c274", size = 440175, upload-time = "2025-10-10T03:54:35.942Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7e/b9287763159e700e335028bc1824359dc736fa9b829dacedace91a39b37e/httptools-0.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f65744d7a8bdb4bda5e1fa23e4ba16832860606fcc09d674d56e425e991539ec", size = 440310, upload-time = "2025-10-10T03:54:37.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/07/5b614f592868e07f5c94b1f301b5e14a21df4e8076215a3bccb830a687d8/httptools-0.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:135fbe974b3718eada677229312e97f3b31f8a9c8ffa3ae6f565bf808d5b6bcb", size = 86875, upload-time = "2025-10-10T03:54:38.421Z" },
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -1057,6 +1393,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1117,6 +1465,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+]
+
+[[package]]
+name = "marshmallow"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-datetime-fromisoformat", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
 ]
 
 [[package]]
@@ -1181,9 +1542,19 @@ wheels = [
 ]
 
 [[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
 name = "movici"
 source = { editable = "." }
 dependencies = [
+    { name = "movici-data-core" },
     { name = "movici-drinking-water-model" },
     { name = "movici-simulation-core" },
     { name = "movici-transport-assignment-model" },
@@ -1210,6 +1581,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "movici-data-core", editable = "packages/data-core" },
     { name = "movici-drinking-water-model", editable = "packages/drinking-water" },
     { name = "movici-simulation-core", editable = "packages/simulation-core" },
     { name = "movici-transport-assignment-model", editable = "packages/transport-assignment" },
@@ -1231,6 +1603,43 @@ docs = [
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxcontrib-plantuml" },
 ]
+
+[[package]]
+name = "movici-data-core"
+source = { editable = "packages/data-core" }
+dependencies = [
+    { name = "fastapi", extra = ["standard"] },
+    { name = "marshmallow" },
+    { name = "movici-simulation-core" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "orjson" },
+    { name = "sqlalchemy" },
+    { name = "svcs" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+]
+sqlite = [
+    { name = "aiosqlite" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", extras = ["standard"] },
+    { name = "marshmallow", specifier = ">=4.3.0" },
+    { name = "movici-simulation-core", editable = "packages/simulation-core" },
+    { name = "numpy" },
+    { name = "orjson", specifier = ">=3.11.7" },
+    { name = "sqlalchemy" },
+    { name = "svcs" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-asyncio", specifier = ">=1.3.0" }]
+sqlite = [{ name = "aiosqlite", specifier = ">=0.22.1" }]
 
 [[package]]
 name = "movici-drinking-water-model"
@@ -1533,10 +1942,14 @@ name = "netcdf4"
 version = "1.7.4"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -1584,10 +1997,14 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -1750,10 +2167,14 @@ name = "numpy"
 version = "2.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -1960,10 +2381,14 @@ name = "pandas"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -2188,6 +2613,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
+]
+
 [[package]]
 name = "pydantic-core"
 version = "2.41.5"
@@ -2276,6 +2706,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
     { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
     { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-extra-types"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/71/dba38ee2651f84f7842206adbd2233d8bbdb59fb85e9fa14232486a8c471/pydantic_extra_types-2.11.1.tar.gz", hash = "sha256:46792d2307383859e923d8fcefa82108b1a141f8a9c0198982b3832ab5ef1049", size = 172002, upload-time = "2026-03-16T08:08:03.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/c1/3226e6d7f5a4f736f38ac11a6fbb262d701889802595cdb0f53a885ac2e0/pydantic_extra_types-2.11.1-py3-none-any.whl", hash = "sha256:1722ea2bddae5628ace25f2aa685b69978ef533123e5638cfbddb999e0100ec1", size = 79526, upload-time = "2026-03-16T08:08:02.533Z" },
 ]
 
 [[package]]
@@ -2406,10 +2849,14 @@ name = "pyproj"
 version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -2477,6 +2924,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2495,6 +2956,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]
@@ -2642,6 +3112,124 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-toolkit"
+version = "0.19.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/ba/dae9e3096651042754da419a4042bc1c75e07d615f9b15066d738838e4df/rich_toolkit-0.19.7.tar.gz", hash = "sha256:133c0915872da91d4c25d85342d5ec1dfacc69b63448af1a08a0d4b4f23ef46e", size = 195877, upload-time = "2026-02-24T16:06:20.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/3c/c923619f6d2f5fafcc96fec0aaf9550a46cd5b6481f06e0c6b66a2a4fed0/rich_toolkit-0.19.7-py3-none-any.whl", hash = "sha256:0288e9203728c47c5a4eb60fd2f0692d9df7455a65901ab6f898437a2ba5989d", size = 32963, upload-time = "2026-02-24T16:06:22.066Z" },
+]
+
+[[package]]
+name = "rignore"
+version = "0.7.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/f5/8bed2310abe4ae04b67a38374a4d311dd85220f5d8da56f47ae9361be0b0/rignore-0.7.6.tar.gz", hash = "sha256:00d3546cd793c30cb17921ce674d2c8f3a4b00501cb0e3dd0e82217dbeba2671", size = 57140, upload-time = "2025-11-05T21:41:21.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/7a/b970cd0138b0ece72eb28f086e933f9ed75b795716ad3de5ab22994b3b54/rignore-0.7.6-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:f3c74a7e5ee77aea669c95fdb3933f2a6c7549893700082e759128a29cf67e45", size = 884999, upload-time = "2025-11-05T20:42:38.373Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/05/23faca29616d8966ada63fb0e13c214107811fa9a0aba2275e4c7ca63bd5/rignore-0.7.6-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b7202404958f5fe3474bac91f65350f0b1dde1a5e05089f2946549b7e91e79ec", size = 824824, upload-time = "2025-11-05T20:42:22.1Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/2e/05a1e61f04cf2548524224f0b5f21ca19ea58f7273a863bac10846b8ff69/rignore-0.7.6-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6bde7c5835fa3905bfb7e329a4f1d7eccb676de63da7a3f934ddd5c06df20597", size = 899121, upload-time = "2025-11-05T20:40:48.94Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/35/71518847e10bdbf359badad8800e4681757a01f4777b3c5e03dbde8a42d8/rignore-0.7.6-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:626c3d4ba03af266694d25101bc1d8d16eda49c5feb86cedfec31c614fceca7d", size = 873813, upload-time = "2025-11-05T20:41:04.71Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/c8/32ae405d3e7fd4d9f9b7838f2fcca0a5005bb87fa514b83f83fd81c0df22/rignore-0.7.6-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0a43841e651e7a05a4274b9026cc408d1912e64016ede8cd4c145dae5d0635be", size = 1168019, upload-time = "2025-11-05T20:41:20.723Z" },
+    { url = "https://files.pythonhosted.org/packages/25/98/013c955982bc5b4719bf9a5bea58be317eea28aa12bfd004025e3cd7c000/rignore-0.7.6-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7978c498dbf7f74d30cdb8859fe612167d8247f0acd377ae85180e34490725da", size = 942822, upload-time = "2025-11-05T20:41:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/90/fb/9a3f3156c6ed30bcd597e63690353edac1fcffe9d382ad517722b56ac195/rignore-0.7.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d22f72ab695c07d2d96d2a645208daff17084441b5d58c07378c9dd6f9c4c87", size = 959820, upload-time = "2025-11-05T20:42:06.364Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b2/93bf609633021e9658acaff24cfb055d8cdaf7f5855d10ebb35307900dda/rignore-0.7.6-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d5bd8e1a91ed1a789b2cbe39eeea9204a6719d4f2cf443a9544b521a285a295f", size = 985050, upload-time = "2025-11-05T20:41:51.124Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/ec2d040469bdfd7b743df10f2201c5d285009a4263d506edbf7a06a090bb/rignore-0.7.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:bc1fc03efad5789365018e94ac4079f851a999bc154d1551c45179f7fcf45322", size = 1079164, upload-time = "2025-11-05T21:40:10.368Z" },
+    { url = "https://files.pythonhosted.org/packages/df/26/4b635f4ea5baf4baa8ba8eee06163f6af6e76dfbe72deb57da34bb24b19d/rignore-0.7.6-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:ce2617fe28c51367fd8abfd4eeea9e61664af63c17d4ea00353d8ef56dfb95fa", size = 1139028, upload-time = "2025-11-05T21:40:27.977Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/54/a3147ebd1e477b06eb24e2c2c56d951ae5faa9045b7b36d7892fec5080d9/rignore-0.7.6-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:7c4ad2cee85068408e7819a38243043214e2c3047e9bd4c506f8de01c302709e", size = 1119024, upload-time = "2025-11-05T21:40:45.148Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f4/27475db769a57cff18fe7e7267b36e6cdb5b1281caa185ba544171106cba/rignore-0.7.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:02cd240bfd59ecc3907766f4839cbba20530a2e470abca09eaa82225e4d946fb", size = 1128531, upload-time = "2025-11-05T21:41:02.734Z" },
+    { url = "https://files.pythonhosted.org/packages/97/32/6e782d3b352e4349fa0e90bf75b13cb7f11d8908b36d9e2b262224b65d9a/rignore-0.7.6-cp310-cp310-win32.whl", hash = "sha256:fe2bd8fa1ff555259df54c376abc73855cb02628a474a40d51b358c3a1ddc55b", size = 646817, upload-time = "2025-11-05T21:41:47.51Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8a/53185c69abb3bb362e8a46b8089999f820bf15655629ff8395107633c8ab/rignore-0.7.6-cp310-cp310-win_amd64.whl", hash = "sha256:d80afd6071c78baf3765ec698841071b19e41c326f994cfa69b5a1df676f5d39", size = 727001, upload-time = "2025-11-05T21:41:32.778Z" },
+    { url = "https://files.pythonhosted.org/packages/25/41/b6e2be3069ef3b7f24e35d2911bd6deb83d20ed5642ad81d5a6d1c015473/rignore-0.7.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:40be8226e12d6653abbebaffaea2885f80374c1c8f76fe5ca9e0cadd120a272c", size = 885285, upload-time = "2025-11-05T20:42:39.763Z" },
+    { url = "https://files.pythonhosted.org/packages/52/66/ba7f561b6062402022887706a7f2b2c2e2e2a28f1e3839202b0a2f77e36d/rignore-0.7.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:182f4e5e4064d947c756819446a7d4cdede8e756b8c81cf9e509683fe38778d7", size = 823882, upload-time = "2025-11-05T20:42:23.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/81/4087453df35a90b07370647b19017029324950c1b9137d54bf1f33843f17/rignore-0.7.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16b63047648a916a87be1e51bb5c009063f1b8b6f5afe4f04f875525507e63dc", size = 899362, upload-time = "2025-11-05T20:40:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c9/390a8fdfabb76d71416be773bd9f162977bd483084f68daf19da1dec88a6/rignore-0.7.6-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ba5524f5178deca4d7695e936604ebc742acb8958f9395776e1fcb8133f8257a", size = 873633, upload-time = "2025-11-05T20:41:06.193Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c9/79404fcb0faa76edfbc9df0901f8ef18568d1104919ebbbad6d608c888d1/rignore-0.7.6-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:62020dbb89a1dd4b84ab3d60547b3b2eb2723641d5fb198463643f71eaaed57d", size = 1167633, upload-time = "2025-11-05T20:41:22.491Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/8d/b3466d32d445d158a0aceb80919085baaae495b1f540fb942f91d93b5e5b/rignore-0.7.6-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b34acd532769d5a6f153a52a98dcb81615c949ab11697ce26b2eb776af2e174d", size = 941434, upload-time = "2025-11-05T20:41:38.151Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/40/9cd949761a7af5bc27022a939c91ff622d29c7a0b66d0c13a863097dde2d/rignore-0.7.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c5e53b752f9de44dff7b3be3c98455ce3bf88e69d6dc0cf4f213346c5e3416c", size = 959461, upload-time = "2025-11-05T20:42:08.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/87/1e1a145731f73bdb7835e11f80da06f79a00d68b370d9a847de979575e6d/rignore-0.7.6-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:25b3536d13a5d6409ce85f23936f044576eeebf7b6db1d078051b288410fc049", size = 985323, upload-time = "2025-11-05T20:41:52.735Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/31/1ecff992fc3f59c4fcdcb6c07d5f6c1e6dfb55ccda19c083aca9d86fa1c6/rignore-0.7.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6e01cad2b0b92f6b1993f29fc01f23f2d78caf4bf93b11096d28e9d578eb08ce", size = 1079173, upload-time = "2025-11-05T21:40:12.007Z" },
+    { url = "https://files.pythonhosted.org/packages/17/18/162eedadb4c2282fa4c521700dbf93c9b14b8842e8354f7d72b445b8d593/rignore-0.7.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5991e46ab9b4868334c9e372ab0892b0150f3f586ff2b1e314272caeb38aaedb", size = 1139012, upload-time = "2025-11-05T21:40:29.399Z" },
+    { url = "https://files.pythonhosted.org/packages/78/96/a9ca398a8af74bb143ad66c2a31303c894111977e28b0d0eab03867f1b43/rignore-0.7.6-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6c8ae562e5d1246cba5eaeb92a47b2a279e7637102828dde41dcbe291f529a3e", size = 1118827, upload-time = "2025-11-05T21:40:46.6Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/22/1c1a65047df864def9a047dbb40bc0b580b8289a4280e62779cd61ae21f2/rignore-0.7.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:aaf938530dcc0b47c4cfa52807aa2e5bfd5ca6d57a621125fe293098692f6345", size = 1128182, upload-time = "2025-11-05T21:41:04.239Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/f4/1526eb01fdc2235aca1fd9d0189bee4021d009a8dcb0161540238c24166e/rignore-0.7.6-cp311-cp311-win32.whl", hash = "sha256:166ebce373105dd485ec213a6a2695986346e60c94ff3d84eb532a237b24a4d5", size = 646547, upload-time = "2025-11-05T21:41:49.439Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/c8/dda0983e1845706beb5826459781549a840fe5a7eb934abc523e8cd17814/rignore-0.7.6-cp311-cp311-win_amd64.whl", hash = "sha256:44f35ee844b1a8cea50d056e6a595190ce9d42d3cccf9f19d280ae5f3058973a", size = 727139, upload-time = "2025-11-05T21:41:34.367Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/47/eb1206b7bf65970d41190b879e1723fc6bbdb2d45e53565f28991a8d9d96/rignore-0.7.6-cp311-cp311-win_arm64.whl", hash = "sha256:14b58f3da4fa3d5c3fa865cab49821675371f5e979281c683e131ae29159a581", size = 657598, upload-time = "2025-11-05T21:41:23.758Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0e/012556ef3047a2628842b44e753bb15f4dc46806780ff090f1e8fe4bf1eb/rignore-0.7.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:03e82348cb7234f8d9b2834f854400ddbbd04c0f8f35495119e66adbd37827a8", size = 883488, upload-time = "2025-11-05T20:42:41.359Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b0/d4f1f3fe9eb3f8e382d45ce5b0547ea01c4b7e0b4b4eb87bcd66a1d2b888/rignore-0.7.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b9e624f6be6116ea682e76c5feb71ea91255c67c86cb75befe774365b2931961", size = 820411, upload-time = "2025-11-05T20:42:24.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/c8/dea564b36dedac8de21c18e1851789545bc52a0c22ece9843444d5608a6a/rignore-0.7.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bda49950d405aa8d0ebe26af807c4e662dd281d926530f03f29690a2e07d649a", size = 897821, upload-time = "2025-11-05T20:40:52.613Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2b/ee96db17ac1835e024c5d0742eefb7e46de60020385ac883dd3d1cde2c1f/rignore-0.7.6-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b5fd5ab3840b8c16851d327ed06e9b8be6459702a53e5ab1fc4073b684b3789e", size = 873963, upload-time = "2025-11-05T20:41:07.49Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8c/ad5a57bbb9d14d5c7e5960f712a8a0b902472ea3f4a2138cbf70d1777b75/rignore-0.7.6-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ced2a248352636a5c77504cb755dc02c2eef9a820a44d3f33061ce1bb8a7f2d2", size = 1169216, upload-time = "2025-11-05T20:41:23.73Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e6/5b00bc2a6bc1701e6878fca798cf5d9125eb3113193e33078b6fc0d99123/rignore-0.7.6-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a04a3b73b75ddc12c9c9b21efcdaab33ca3832941d6f1d67bffd860941cd448a", size = 942942, upload-time = "2025-11-05T20:41:39.393Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e5/7f99bd0cc9818a91d0e8b9acc65b792e35750e3bdccd15a7ee75e64efca4/rignore-0.7.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d24321efac92140b7ec910ac7c53ab0f0c86a41133d2bb4b0e6a7c94967f44dd", size = 959787, upload-time = "2025-11-05T20:42:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/55/54/2ffea79a7c1eabcede1926347ebc2a81bc6b81f447d05b52af9af14948b9/rignore-0.7.6-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c7aa109d41e593785c55fdaa89ad80b10330affa9f9d3e3a51fa695f739b20", size = 984245, upload-time = "2025-11-05T20:41:54.062Z" },
+    { url = "https://files.pythonhosted.org/packages/41/f7/e80f55dfe0f35787fa482aa18689b9c8251e045076c35477deb0007b3277/rignore-0.7.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1734dc49d1e9501b07852ef44421f84d9f378da9fbeda729e77db71f49cac28b", size = 1078647, upload-time = "2025-11-05T21:40:13.463Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/cf/2c64f0b6725149f7c6e7e5a909d14354889b4beaadddaa5fff023ec71084/rignore-0.7.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:5719ea14ea2b652c0c0894be5dfde954e1853a80dea27dd2fbaa749618d837f5", size = 1139186, upload-time = "2025-11-05T21:40:31.27Z" },
+    { url = "https://files.pythonhosted.org/packages/75/95/a86c84909ccc24af0d094b50d54697951e576c252a4d9f21b47b52af9598/rignore-0.7.6-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8e23424fc7ce35726854f639cb7968151a792c0c3d9d082f7f67e0c362cfecca", size = 1117604, upload-time = "2025-11-05T21:40:48.07Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5e/13b249613fd5d18d58662490ab910a9f0be758981d1797789913adb4e918/rignore-0.7.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3efdcf1dd84d45f3e2bd2f93303d9be103888f56dfa7c3349b5bf4f0657ec696", size = 1127725, upload-time = "2025-11-05T21:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/28/fa5dcd1e2e16982c359128664e3785f202d3eca9b22dd0b2f91c4b3d242f/rignore-0.7.6-cp312-cp312-win32.whl", hash = "sha256:ccca9d1a8b5234c76b71546fc3c134533b013f40495f394a65614a81f7387046", size = 646145, upload-time = "2025-11-05T21:41:51.096Z" },
+    { url = "https://files.pythonhosted.org/packages/26/87/69387fb5dd81a0f771936381431780b8cf66fcd2cfe9495e1aaf41548931/rignore-0.7.6-cp312-cp312-win_amd64.whl", hash = "sha256:c96a285e4a8bfec0652e0bfcf42b1aabcdda1e7625f5006d188e3b1c87fdb543", size = 726090, upload-time = "2025-11-05T21:41:36.485Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5f/e8418108dcda8087fb198a6f81caadbcda9fd115d61154bf0df4d6d3619b/rignore-0.7.6-cp312-cp312-win_arm64.whl", hash = "sha256:a64a750e7a8277a323f01ca50b7784a764845f6cce2fe38831cb93f0508d0051", size = 656317, upload-time = "2025-11-05T21:41:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8a/a4078f6e14932ac7edb171149c481de29969d96ddee3ece5dc4c26f9e0c3/rignore-0.7.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:2bdab1d31ec9b4fb1331980ee49ea051c0d7f7bb6baa28b3125ef03cdc48fdaf", size = 883057, upload-time = "2025-11-05T20:42:42.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8f/f8daacd177db4bf7c2223bab41e630c52711f8af9ed279be2058d2fe4982/rignore-0.7.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:90f0a00ce0c866c275bf888271f1dc0d2140f29b82fcf33cdbda1e1a6af01010", size = 820150, upload-time = "2025-11-05T20:42:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/36/31/b65b837e39c3f7064c426754714ac633b66b8c2290978af9d7f513e14aa9/rignore-0.7.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1ad295537041dc2ed4b540fb1a3906bd9ede6ccdad3fe79770cd89e04e3c73c", size = 897406, upload-time = "2025-11-05T20:40:53.854Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/58/1970ce006c427e202ac7c081435719a076c478f07b3a23f469227788dc23/rignore-0.7.6-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f782dbd3a65a5ac85adfff69e5c6b101285ef3f845c3a3cae56a54bebf9fe116", size = 874050, upload-time = "2025-11-05T20:41:08.922Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/eb45db9f90137329072a732273be0d383cb7d7f50ddc8e0bceea34c1dfdf/rignore-0.7.6-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65cece3b36e5b0826d946494734c0e6aaf5a0337e18ff55b071438efe13d559e", size = 1167835, upload-time = "2025-11-05T20:41:24.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f1/6f1d72ddca41a64eed569680587a1236633587cc9f78136477ae69e2c88a/rignore-0.7.6-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d7e4bb66c13cd7602dc8931822c02dfbbd5252015c750ac5d6152b186f0a8be0", size = 941945, upload-time = "2025-11-05T20:41:40.628Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6f/2f178af1c1a276a065f563ec1e11e7a9e23d4996fd0465516afce4b5c636/rignore-0.7.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:297e500c15766e196f68aaaa70e8b6db85fa23fdc075b880d8231fdfba738cd7", size = 959067, upload-time = "2025-11-05T20:42:11.09Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/db/423a81c4c1e173877c7f9b5767dcaf1ab50484a94f60a0b2ed78be3fa765/rignore-0.7.6-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a07084211a8d35e1a5b1d32b9661a5ed20669970b369df0cf77da3adea3405de", size = 984438, upload-time = "2025-11-05T20:41:55.443Z" },
+    { url = "https://files.pythonhosted.org/packages/31/eb/c4f92cc3f2825d501d3c46a244a671eb737fc1bcf7b05a3ecd34abb3e0d7/rignore-0.7.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:181eb2a975a22256a1441a9d2f15eb1292839ea3f05606620bd9e1938302cf79", size = 1078365, upload-time = "2025-11-05T21:40:15.148Z" },
+    { url = "https://files.pythonhosted.org/packages/26/09/99442f02794bd7441bfc8ed1c7319e890449b816a7493b2db0e30af39095/rignore-0.7.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:7bbcdc52b5bf9f054b34ce4af5269df5d863d9c2456243338bc193c28022bd7b", size = 1139066, upload-time = "2025-11-05T21:40:32.771Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/88/bcfc21e520bba975410e9419450f4b90a2ac8236b9a80fd8130e87d098af/rignore-0.7.6-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f2e027a6da21a7c8c0d87553c24ca5cc4364def18d146057862c23a96546238e", size = 1118036, upload-time = "2025-11-05T21:40:49.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/25/d37215e4562cda5c13312636393aea0bafe38d54d4e0517520a4cc0753ec/rignore-0.7.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee4a18b82cbbc648e4aac1510066682fe62beb5dc88e2c67c53a83954e541360", size = 1127550, upload-time = "2025-11-05T21:41:07.648Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/76/a264ab38bfa1620ec12a8ff1c07778da89e16d8c0f3450b0333020d3d6dc/rignore-0.7.6-cp313-cp313-win32.whl", hash = "sha256:a7d7148b6e5e95035d4390396895adc384d37ff4e06781a36fe573bba7c283e5", size = 646097, upload-time = "2025-11-05T21:41:53.201Z" },
+    { url = "https://files.pythonhosted.org/packages/62/44/3c31b8983c29ea8832b6082ddb1d07b90379c2d993bd20fce4487b71b4f4/rignore-0.7.6-cp313-cp313-win_amd64.whl", hash = "sha256:b037c4b15a64dced08fc12310ee844ec2284c4c5c1ca77bc37d0a04f7bff386e", size = 726170, upload-time = "2025-11-05T21:41:38.131Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/41/e26a075cab83debe41a42661262f606166157df84e0e02e2d904d134c0d8/rignore-0.7.6-cp313-cp313-win_arm64.whl", hash = "sha256:e47443de9b12fe569889bdbe020abe0e0b667516ee2ab435443f6d0869bd2804", size = 656184, upload-time = "2025-11-05T21:41:27.396Z" },
+    { url = "https://files.pythonhosted.org/packages/85/12/62d690b4644c330d7ac0f739b7f078190ab4308faa909a60842d0e4af5b2/rignore-0.7.6-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c3d3a523af1cd4ed2c0cba8d277a32d329b0c96ef9901fb7ca45c8cfaccf31a5", size = 887462, upload-time = "2025-11-05T20:42:50.804Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bc/6528a0e97ed2bd7a7c329183367d1ffbc5b9762ae8348d88dae72cc9d1f5/rignore-0.7.6-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:990853566e65184a506e1e2af2d15045afad3ebaebb8859cb85b882081915110", size = 826918, upload-time = "2025-11-05T20:42:33.689Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2c/7d7bad116e09a04e9e1688c6f891fa2d4fd33f11b69ac0bd92419ddebeae/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1cab9ff2e436ce7240d7ee301c8ef806ed77c1fd6b8a8239ff65f9bbbcb5b8a3", size = 900922, upload-time = "2025-11-05T20:41:00.361Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ba/e5ea89fbde8e37a90ce456e31c5e9d85512cef5ae38e0f4d2426eb776a19/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d1a6671b2082c13bfd9a5cf4ce64670f832a6d41470556112c4ab0b6519b2fc4", size = 876987, upload-time = "2025-11-05T20:41:16.219Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/fb/93d14193f0ec0c3d35b763f0a000e9780f63b2031f3d3756442c2152622d/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2468729b4c5295c199d084ab88a40afcb7c8b974276805105239c07855bbacee", size = 1171110, upload-time = "2025-11-05T20:41:32.631Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/46/08436312ff96ffa29cfa4e1a987efc37e094531db46ba5e9fda9bb792afd/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:775710777fd71e5fdf54df69cdc249996a1d6f447a2b5bfb86dbf033fddd9cf9", size = 943339, upload-time = "2025-11-05T20:41:47.128Z" },
+    { url = "https://files.pythonhosted.org/packages/34/28/3b3c51328f505cfaf7e53f408f78a1e955d561135d02f9cb0341ea99f69a/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4565407f4a77f72cf9d91469e75d15d375f755f0a01236bb8aaa176278cc7085", size = 961680, upload-time = "2025-11-05T20:42:18.061Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9e/cbff75c8676d4f4a90bd58a1581249d255c7305141b0868f0abc0324836b/rignore-0.7.6-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:dc44c33f8fb2d5c9da748de7a6e6653a78aa740655e7409895e94a247ffa97c8", size = 987045, upload-time = "2025-11-05T20:42:02.315Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/25/d802d1d369502a7ddb8816059e7c79d2d913e17df975b863418e0aca4d8a/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:8f32478f05540513c11923e8838afab9efef0131d66dca7f67f0e1bbd118af6a", size = 1080310, upload-time = "2025-11-05T21:40:23.184Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/250b785c2e473b1ab763eaf2be820934c2a5409a722e94b279dddac21c7d/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:1b63a3dd76225ea35b01dd6596aa90b275b5d0f71d6dc28fce6dd295d98614aa", size = 1140998, upload-time = "2025-11-05T21:40:40.603Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d6/bb42fd2a8bba6aea327962656e20621fd495523259db40cfb4c5f760f05c/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:fe6c41175c36554a4ef0994cd1b4dbd6d73156fca779066456b781707402048e", size = 1121178, upload-time = "2025-11-05T21:40:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/97/f4/aeb548374129dce3dc191a4bb598c944d9ed663f467b9af830315d86059c/rignore-0.7.6-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:9a0c6792406ae36f4e7664dc772da909451d46432ff8485774526232d4885063", size = 1130190, upload-time = "2025-11-05T21:41:16.403Z" },
+    { url = "https://files.pythonhosted.org/packages/82/78/a6250ff0c49a3cdb943910ada4116e708118e9b901c878cfae616c80a904/rignore-0.7.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:a20b6fb61bcced9a83dfcca6599ad45182b06ba720cff7c8d891e5b78db5b65f", size = 886470, upload-time = "2025-11-05T20:42:52.314Z" },
+    { url = "https://files.pythonhosted.org/packages/35/af/c69c0c51b8f9f7914d95c4ea91c29a2ac067572048cae95dd6d2efdbe05d/rignore-0.7.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:392dcabfecbe176c9ebbcb40d85a5e86a5989559c4f988c2741da7daf1b5be25", size = 825976, upload-time = "2025-11-05T20:42:35.118Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d2/1b264f56132264ea609d3213ab603d6a27016b19559a1a1ede1a66a03dcd/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22baa462abdc36fdd5a5e2dae423107723351b85ff093762f9261148b9d0a04a", size = 899739, upload-time = "2025-11-05T20:41:01.518Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e4/b3c5dfdd8d8a10741dfe7199ef45d19a0e42d0c13aa377c83bd6caf65d90/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:53fb28882d2538cb2d231972146c4927a9d9455e62b209f85d634408c4103538", size = 874843, upload-time = "2025-11-05T20:41:17.687Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/10/d6f3750233881a2a154cefc9a6a0a9b19da526b19f7f08221b552c6f827d/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:87409f7eeb1103d6b77f3472a3a0d9a5953e3ae804a55080bdcb0120ee43995b", size = 1170348, upload-time = "2025-11-05T20:41:34.21Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/10/ad98ca05c9771c15af734cee18114a3c280914b6e34fde9ffea2e61e88aa/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:684014e42e4341ab3ea23a203551857fcc03a7f8ae96ca3aefb824663f55db32", size = 942315, upload-time = "2025-11-05T20:41:48.508Z" },
+    { url = "https://files.pythonhosted.org/packages/de/00/ab5c0f872acb60d534e687e629c17e0896c62da9b389c66d3aa16b817aa8/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77356ebb01ba13f8a425c3d30fcad40e57719c0e37670d022d560884a30e4767", size = 961047, upload-time = "2025-11-05T20:42:19.403Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/86/3030fdc363a8f0d1cd155b4c453d6db9bab47a24fcc64d03f61d9d78fe6a/rignore-0.7.6-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6cbd8a48abbd3747a6c830393cd578782fab5d43f4deea48c5f5e344b8fed2b0", size = 986090, upload-time = "2025-11-05T20:42:03.581Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b8/133aa4002cee0ebbb39362f94e4898eec7fbd09cec9fcbce1cd65b355b7f/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2673225dcec7f90497e79438c35e34638d0d0391ccea3cbb79bfb9adc0dc5bd7", size = 1079656, upload-time = "2025-11-05T21:40:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/67/56/36d5d34210e5e7dfcd134eed8335b19e80ae940ee758f493e4f2b344dd70/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_armv7l.whl", hash = "sha256:c081f17290d8a2b96052b79207622aa635686ea39d502b976836384ede3d303c", size = 1139789, upload-time = "2025-11-05T21:40:42.119Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/5b/bb4f9420802bf73678033a4a55ab1bede36ce2e9b41fec5f966d83d932b3/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:57e8327aacc27f921968cb2a174f9e47b084ce9a7dd0122c8132d22358f6bd79", size = 1120308, upload-time = "2025-11-05T21:40:59.402Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8b/a1299085b28a2f6135e30370b126e3c5055b61908622f2488ade67641479/rignore-0.7.6-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:d8955b57e42f2a5434670d5aa7b75eaf6e74602ccd8955dddf7045379cd762fb", size = 1129444, upload-time = "2025-11-05T21:41:17.906Z" },
 ]
 
 [[package]]
@@ -2852,10 +3440,14 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -2906,6 +3498,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/12/d19da97efde68ca1ee5538bb261d5d2c062f0c055575128f11a2730e3ac1/scipy-1.17.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:94055a11dfebe37c656e70317e1996dc197e1a15bbcc351bcdd4610e128fe1ca", size = 37665910, upload-time = "2026-02-23T00:20:34.743Z" },
     { url = "https://files.pythonhosted.org/packages/06/1c/1172a88d507a4baaf72c5a09bb6c018fe2ae0ab622e5830b703a46cc9e44/scipy-1.17.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e30bdeaa5deed6bc27b4cc490823cd0347d7dae09119b8803ae576ea0ce52e4c", size = 36562980, upload-time = "2026-02-23T00:20:40.575Z" },
     { url = "https://files.pythonhosted.org/packages/70/b0/eb757336e5a76dfa7911f63252e3b7d1de00935d7705cf772db5b45ec238/scipy-1.17.1-cp313-cp313t-win_arm64.whl", hash = "sha256:a720477885a9d2411f94a93d16f9d89bad0f28ca23c3f8daa521e2dcc3f44d49", size = 24856543, upload-time = "2026-02-23T00:20:45.313Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
 ]
 
 [[package]]
@@ -2967,6 +3572,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
     { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
     { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+]
+
+[[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
 ]
 
 [[package]]
@@ -3067,10 +3681,14 @@ name = "sphinx"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "alabaster", marker = "python_full_version >= '3.12'" },
@@ -3239,6 +3857,31 @@ wheels = [
 ]
 
 [[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "svcs"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/e1/2d56ec21820cae24a6215dc1d6a224167b0e24368bf53166551064742e0d/svcs-25.1.0.tar.gz", hash = "sha256:64dd74d0c4e8fee79a9ac7550a9d824670b228df390ba1911614e29b59b3f2c2", size = 714086, upload-time = "2025-01-25T13:15:21.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/1c/a6b5d90a9ca479805798276728ccbbdff0c7228e2ea93b1f731779d635e3/svcs-25.1.0-py3-none-any.whl", hash = "sha256:df49cb7d1a05dfd2dd60af1a2cb84b9c3bb0a74728833cb8c54a7ceeecce6c97", size = 19456, upload-time = "2025-01-25T13:15:19.677Z" },
+]
+
+[[package]]
 name = "tables"
 version = "3.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3282,10 +3925,14 @@ name = "tables"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.12' and platform_machine == 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and platform_machine != 'ARM64' and sys_platform == 'win32'",
-    "python_full_version >= '3.12' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.13' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.11.*' and platform_machine == 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and platform_machine != 'ARM64' and sys_platform == 'win32'",
     "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
@@ -3370,6 +4017,21 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7b/27/ede8cec7596e0041ba7e7b80b47d132562f56ff454313a16f6084e555c9f/typer-0.25.0.tar.gz", hash = "sha256:123eaf9f19bb40fd268310e12a542c0c6b4fab9c98d9d23342a01ff95e3ce930", size = 120150, upload-time = "2026-04-26T08:46:14.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/72/193d4e586ec5a4db834a36bbeb47641a62f951f114ffd0fe5b1b46e8d56f/typer-0.25.0-py3-none-any.whl", hash = "sha256:ac01b48823d3db9a83c9e164338057eadbb1c9957a2a6b4eeb486669c560b5dc", size = 55993, upload-time = "2026-04-26T08:46:15.889Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3406,6 +4068,193 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/14/ecceb239b65adaaf7fde510aa8bd534075695d1e5f8dadfa32b5723d9cfb/uvloop-0.22.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ef6f0d4cc8a9fa1f6a910230cd53545d9a14479311e87e3cb225495952eb672c", size = 1343335, upload-time = "2025-10-16T22:16:11.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ae/6f6f9af7f590b319c94532b9567409ba11f4fa71af1148cab1bf48a07048/uvloop-0.22.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7cd375a12b71d33d46af85a3343b35d98e8116134ba404bd657b3b1d15988792", size = 742903, upload-time = "2025-10-16T22:16:12.979Z" },
+    { url = "https://files.pythonhosted.org/packages/09/bd/3667151ad0702282a1f4d5d29288fce8a13c8b6858bf0978c219cd52b231/uvloop-0.22.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac33ed96229b7790eb729702751c0e93ac5bc3bcf52ae9eccbff30da09194b86", size = 3648499, upload-time = "2025-10-16T22:16:14.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f6/21657bb3beb5f8c57ce8be3b83f653dd7933c2fd00545ed1b092d464799a/uvloop-0.22.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:481c990a7abe2c6f4fc3d98781cc9426ebd7f03a9aaa7eb03d3bfc68ac2a46bd", size = 3700133, upload-time = "2025-10-16T22:16:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/09/e0/604f61d004ded805f24974c87ddd8374ef675644f476f01f1df90e4cdf72/uvloop-0.22.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a592b043a47ad17911add5fbd087c76716d7c9ccc1d64ec9249ceafd735f03c2", size = 3512681, upload-time = "2025-10-16T22:16:18.07Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/8491fd370b0230deb5eac69c7aae35b3be527e25a911c0acdffb922dc1cd/uvloop-0.22.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:1489cf791aa7b6e8c8be1c5a080bae3a672791fcb4e9e12249b05862a2ca9cec", size = 3615261, upload-time = "2025-10-16T22:16:19.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/d5/69900f7883235562f1f50d8184bb7dd84a2fb61e9ec63f3782546fdbd057/uvloop-0.22.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:c60ebcd36f7b240b30788554b6f0782454826a0ed765d8430652621b5de674b9", size = 1352420, upload-time = "2025-10-16T22:16:21.187Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/73/c4e271b3bce59724e291465cc936c37758886a4868787da0278b3b56b905/uvloop-0.22.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3b7f102bf3cb1995cfeaee9321105e8f5da76fdb104cdad8986f85461a1b7b77", size = 748677, upload-time = "2025-10-16T22:16:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/86/94/9fb7fad2f824d25f8ecac0d70b94d0d48107ad5ece03769a9c543444f78a/uvloop-0.22.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53c85520781d84a4b8b230e24a5af5b0778efdb39142b424990ff1ef7c48ba21", size = 3753819, upload-time = "2025-10-16T22:16:23.903Z" },
+    { url = "https://files.pythonhosted.org/packages/74/4f/256aca690709e9b008b7108bc85fba619a2bc37c6d80743d18abad16ee09/uvloop-0.22.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56a2d1fae65fd82197cb8c53c367310b3eabe1bbb9fb5a04d28e3e3520e4f702", size = 3804529, upload-time = "2025-10-16T22:16:25.246Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/03c05ae4737e871923d21a76fe28b6aad57f5c03b6e6bfcfa5ad616013e4/uvloop-0.22.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:40631b049d5972c6755b06d0bfe8233b1bd9a8a6392d9d1c45c10b6f9e9b2733", size = 3621267, upload-time = "2025-10-16T22:16:26.819Z" },
+    { url = "https://files.pythonhosted.org/packages/75/be/f8e590fe61d18b4a92070905497aec4c0e64ae1761498cad09023f3f4b3e/uvloop-0.22.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:535cc37b3a04f6cd2c1ef65fa1d370c9a35b6695df735fcff5427323f2cd5473", size = 3723105, upload-time = "2025-10-16T22:16:28.252Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/1a/206e8cf2dd86fddf939165a57b4df61607a1e0add2785f170a3f616b7d9f/watchfiles-1.1.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:eef58232d32daf2ac67f42dea51a2c80f0d03379075d44a587051e63cc2e368c", size = 407318, upload-time = "2025-10-14T15:04:18.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/0f/abaf5262b9c496b5dad4ed3c0e799cbecb1f8ea512ecb6ddd46646a9fca3/watchfiles-1.1.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:03fa0f5237118a0c5e496185cafa92878568b652a2e9a9382a5151b1a0380a43", size = 394478, upload-time = "2025-10-14T15:04:20.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/04/9cc0ba88697b34b755371f5ace8d3a4d9a15719c07bdc7bd13d7d8c6a341/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8ca65483439f9c791897f7db49202301deb6e15fe9f8fe2fed555bf986d10c31", size = 449894, upload-time = "2025-10-14T15:04:21.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9c/eda4615863cd8621e89aed4df680d8c3ec3da6a4cf1da113c17decd87c7f/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f0ab1c1af0cb38e3f598244c17919fb1a84d1629cc08355b0074b6d7f53138ac", size = 459065, upload-time = "2025-10-14T15:04:22.795Z" },
+    { url = "https://files.pythonhosted.org/packages/84/13/f28b3f340157d03cbc8197629bc109d1098764abe1e60874622a0be5c112/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3bc570d6c01c206c46deb6e935a260be44f186a2f05179f52f7fcd2be086a94d", size = 488377, upload-time = "2025-10-14T15:04:24.138Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/cfa597fa9389e122488f7ffdbd6db505b3b915ca7435ecd7542e855898c2/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e84087b432b6ac94778de547e08611266f1f8ffad28c0ee4c82e028b0fc5966d", size = 595837, upload-time = "2025-10-14T15:04:25.057Z" },
+    { url = "https://files.pythonhosted.org/packages/57/1e/68c1ed5652b48d89fc24d6af905d88ee4f82fa8bc491e2666004e307ded1/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:620bae625f4cb18427b1bb1a2d9426dc0dd5a5ba74c7c2cdb9de405f7b129863", size = 473456, upload-time = "2025-10-14T15:04:26.497Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/dc/1a680b7458ffa3b14bb64878112aefc8f2e4f73c5af763cbf0bd43100658/watchfiles-1.1.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:544364b2b51a9b0c7000a4b4b02f90e9423d97fbbf7e06689236443ebcad81ab", size = 455614, upload-time = "2025-10-14T15:04:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a5/3d782a666512e01eaa6541a72ebac1d3aae191ff4a31274a66b8dd85760c/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:bbe1ef33d45bc71cf21364df962af171f96ecaeca06bd9e3d0b583efb12aec82", size = 630690, upload-time = "2025-10-14T15:04:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/73/bb5f38590e34687b2a9c47a244aa4dd50c56a825969c92c9c5fc7387cea1/watchfiles-1.1.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:1a0bb430adb19ef49389e1ad368450193a90038b5b752f4ac089ec6942c4dff4", size = 622459, upload-time = "2025-10-14T15:04:29.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/ac/c9bb0ec696e07a20bd58af5399aeadaef195fb2c73d26baf55180fe4a942/watchfiles-1.1.1-cp310-cp310-win32.whl", hash = "sha256:3f6d37644155fb5beca5378feb8c1708d5783145f2a0f1c4d5a061a210254844", size = 272663, upload-time = "2025-10-14T15:04:30.435Z" },
+    { url = "https://files.pythonhosted.org/packages/11/a0/a60c5a7c2ec59fa062d9a9c61d02e3b6abd94d32aac2d8344c4bdd033326/watchfiles-1.1.1-cp310-cp310-win_amd64.whl", hash = "sha256:a36d8efe0f290835fd0f33da35042a1bb5dc0e83cbc092dcf69bce442579e88e", size = 287453, upload-time = "2025-10-14T15:04:31.53Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f8/2c5f479fb531ce2f0564eda479faecf253d886b1ab3630a39b7bf7362d46/watchfiles-1.1.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:f57b396167a2565a4e8b5e56a5a1c537571733992b226f4f1197d79e94cf0ae5", size = 406529, upload-time = "2025-10-14T15:04:32.899Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cd/f515660b1f32f65df671ddf6f85bfaca621aee177712874dc30a97397977/watchfiles-1.1.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:421e29339983e1bebc281fab40d812742268ad057db4aee8c4d2bce0af43b741", size = 394384, upload-time = "2025-10-14T15:04:33.761Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/c3/28b7dc99733eab43fca2d10f55c86e03bd6ab11ca31b802abac26b23d161/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e43d39a741e972bab5d8100b5cdacf69db64e34eb19b6e9af162bccf63c5cc6", size = 448789, upload-time = "2025-10-14T15:04:34.679Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/24/33e71113b320030011c8e4316ccca04194bf0cbbaeee207f00cbc7d6b9f5/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f537afb3276d12814082a2e9b242bdcf416c2e8fd9f799a737990a1dbe906e5b", size = 460521, upload-time = "2025-10-14T15:04:35.963Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c3/3c9a55f255aa57b91579ae9e98c88704955fa9dac3e5614fb378291155df/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b2cd9e04277e756a2e2d2543d65d1e2166d6fd4c9b183f8808634fda23f17b14", size = 488722, upload-time = "2025-10-14T15:04:37.091Z" },
+    { url = "https://files.pythonhosted.org/packages/49/36/506447b73eb46c120169dc1717fe2eff07c234bb3232a7200b5f5bd816e9/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f3f58818dc0b07f7d9aa7fe9eb1037aecb9700e63e1f6acfed13e9fef648f5d", size = 596088, upload-time = "2025-10-14T15:04:38.39Z" },
+    { url = "https://files.pythonhosted.org/packages/82/ab/5f39e752a9838ec4d52e9b87c1e80f1ee3ccdbe92e183c15b6577ab9de16/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9bb9f66367023ae783551042d31b1d7fd422e8289eedd91f26754a66f44d5cff", size = 472923, upload-time = "2025-10-14T15:04:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/af/b9/a419292f05e302dea372fa7e6fda5178a92998411f8581b9830d28fb9edb/watchfiles-1.1.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aebfd0861a83e6c3d1110b78ad54704486555246e542be3e2bb94195eabb2606", size = 456080, upload-time = "2025-10-14T15:04:40.643Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c3/d5932fd62bde1a30c36e10c409dc5d54506726f08cb3e1d8d0ba5e2bc8db/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:5fac835b4ab3c6487b5dbad78c4b3724e26bcc468e886f8ba8cc4306f68f6701", size = 629432, upload-time = "2025-10-14T15:04:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/77/16bddd9779fafb795f1a94319dc965209c5641db5bf1edbbccace6d1b3c0/watchfiles-1.1.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:399600947b170270e80134ac854e21b3ccdefa11a9529a3decc1327088180f10", size = 623046, upload-time = "2025-10-14T15:04:42.718Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/f2ecb9a0f342b4bfad13a2787155c6ee7ce792140eac63a34676a2feeef2/watchfiles-1.1.1-cp311-cp311-win32.whl", hash = "sha256:de6da501c883f58ad50db3a32ad397b09ad29865b5f26f64c24d3e3281685849", size = 271473, upload-time = "2025-10-14T15:04:43.624Z" },
+    { url = "https://files.pythonhosted.org/packages/94/bc/f42d71125f19731ea435c3948cad148d31a64fccde3867e5ba4edee901f9/watchfiles-1.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:35c53bd62a0b885bf653ebf6b700d1bf05debb78ad9292cf2a942b23513dc4c4", size = 287598, upload-time = "2025-10-14T15:04:44.516Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/a30f897351f95bbbfb6abcadafbaca711ce1162f4db95fc908c98a9165f3/watchfiles-1.1.1-cp311-cp311-win_arm64.whl", hash = "sha256:57ca5281a8b5e27593cb7d82c2ac927ad88a96ed406aa446f6344e4328208e9e", size = 277210, upload-time = "2025-10-14T15:04:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4c/a888c91e2e326872fa4705095d64acd8aa2fb9c1f7b9bd0588f33850516c/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:17ef139237dfced9da49fb7f2232c86ca9421f666d78c264c7ffca6601d154c3", size = 409611, upload-time = "2025-10-14T15:06:05.809Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c7/5420d1943c8e3ce1a21c0a9330bcf7edafb6aa65d26b21dbb3267c9e8112/watchfiles-1.1.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:672b8adf25b1a0d35c96b5888b7b18699d27d4194bac8beeae75be4b7a3fc9b2", size = 396889, upload-time = "2025-10-14T15:06:07.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e5/0072cef3804ce8d3aaddbfe7788aadff6b3d3f98a286fdbee9fd74ca59a7/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77a13aea58bc2b90173bc69f2a90de8e282648939a00a602e1dc4ee23e26b66d", size = 451616, upload-time = "2025-10-14T15:06:08.072Z" },
+    { url = "https://files.pythonhosted.org/packages/83/4e/b87b71cbdfad81ad7e83358b3e447fedd281b880a03d64a760fe0a11fc2e/watchfiles-1.1.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b495de0bb386df6a12b18335a0285dda90260f51bdb505503c02bcd1ce27a8b", size = 458413, upload-time = "2025-10-14T15:06:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/e500f8b0b77be4ff753ac94dc06b33d8f0d839377fee1b78e8c8d8f031bf/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:db476ab59b6765134de1d4fe96a1a9c96ddf091683599be0f26147ea1b2e4b88", size = 408250, upload-time = "2025-10-14T15:06:10.264Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/74/221f58decd852f4b59cc3354cccaf87e8ef695fede361d03dc9a7396573b/websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a", size = 177343, upload-time = "2026-01-10T09:22:21.28Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0f/22ef6107ee52ab7f0b710d55d36f5a5d3ef19e8a205541a6d7ffa7994e5a/websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0", size = 175021, upload-time = "2026-01-10T09:22:22.696Z" },
+    { url = "https://files.pythonhosted.org/packages/10/40/904a4cb30d9b61c0e278899bf36342e9b0208eb3c470324a9ecbaac2a30f/websockets-16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:583b7c42688636f930688d712885cf1531326ee05effd982028212ccc13e5957", size = 175320, upload-time = "2026-01-10T09:22:23.94Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/2f/4b3ca7e106bc608744b1cdae041e005e446124bebb037b18799c2d356864/websockets-16.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7d837379b647c0c4c2355c2499723f82f1635fd2c26510e1f587d89bc2199e72", size = 183815, upload-time = "2026-01-10T09:22:25.469Z" },
+    { url = "https://files.pythonhosted.org/packages/86/26/d40eaa2a46d4302becec8d15b0fc5e45bdde05191e7628405a19cf491ccd/websockets-16.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df57afc692e517a85e65b72e165356ed1df12386ecb879ad5693be08fac65dde", size = 185054, upload-time = "2026-01-10T09:22:27.101Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ba/6500a0efc94f7373ee8fefa8c271acdfd4dca8bd49a90d4be7ccabfc397e/websockets-16.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:2b9f1e0d69bc60a4a87349d50c09a037a2607918746f07de04df9e43252c77a3", size = 184565, upload-time = "2026-01-10T09:22:28.293Z" },
+    { url = "https://files.pythonhosted.org/packages/04/b4/96bf2cee7c8d8102389374a2616200574f5f01128d1082f44102140344cc/websockets-16.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:335c23addf3d5e6a8633f9f8eda77efad001671e80b95c491dd0924587ece0b3", size = 183848, upload-time = "2026-01-10T09:22:30.394Z" },
+    { url = "https://files.pythonhosted.org/packages/02/8e/81f40fb00fd125357814e8c3025738fc4ffc3da4b6b4a4472a82ba304b41/websockets-16.0-cp310-cp310-win32.whl", hash = "sha256:37b31c1623c6605e4c00d466c9d633f9b812ea430c11c8a278774a1fde1acfa9", size = 178249, upload-time = "2026-01-10T09:22:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5f/7e40efe8df57db9b91c88a43690ac66f7b7aa73a11aa6a66b927e44f26fa/websockets-16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8e1dab317b6e77424356e11e99a432b7cb2f3ec8c5ab4dabbcee6add48f72b35", size = 178685, upload-time = "2026-01-10T09:22:33.345Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Describe your changes
Adds movici-data-core as a package and introduces the main database layer written in SQLAlchemy.


This PR depends on #130
CI depends on #129 

### Details
* the package is called `movici-data-core` and resides in `packages/data-core`
* The database model is based on modern SQLAlchemy and is async. The choice for async was driven by the need for having an async database interface in the Movici Cloud Platform (data-engine)
* A domain model exists in `domain_model.py`, which the api-contract for the SQLAlchemyRepository adheres to. SQLAlchemy models do not leak from the database layer. 
* The envisioned api layer is based on fastapi, which is fully async compatible
* A `SQLAlchemyServer` class is introduced that can setup a database, and is a factory for `SQLAlchemyBackend` classes. This backend class will be the main entry point for the api layer and is similar to a Unit of Work pattern, This class will be further implemented in a future PR
* This PR focuses on the SQLAlchemyRepository classes, which deal with reading from and writing to the database.


### Additional comments
* Initially, the package was designed so that the sqlalchemy based backend/repository could be swapped out for a file based backend, which could be used by `movici-viewer`. However, for complexity and performance reasons it was decided that movici-viewer would make use of the sqlalchemy backend, and introduce logic to import movici data files from disk and convert them to a (sqlite) database as a command.




## Copyright license

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to
 re-/sublicense my contribution
