### PR TITLE
Make FSM composable so that we can customize for specific use cases

### DIFF
--- a/packages/simulation-core/src/movici_simulation_core/messages.py
+++ b/packages/simulation-core/src/movici_simulation_core/messages.py
@@ -116,6 +116,13 @@ class AcknowledgeMessage(Message):
 
 @dataclasses.dataclass
 class QuitMessage(Message):
+    """A message to indicate that we should stop the simulation. Allows models to gracefully
+    terminate.
+
+    :param due_to_failure: flag to indicate that a component has failed and that it is not a
+        regular shutdown
+    """
+
     due_to_failure: bool = False
 
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -20,7 +20,7 @@ from movici_simulation_core.messages import (
 )
 from movici_simulation_core.utils.data_mask import masks_overlap
 
-from .fsm import FSM, Always, State, TransitionsT
+from .fsm import FSM, Always, Condition, FSMConfig, State
 from .interconnectivity import Publisher, format_matrix
 from .stopwatch import ReportingStopwatch, Stopwatch
 
@@ -159,7 +159,9 @@ class ConnectedModel:
 
     quit: t.Optional[QuitMessage] = field(default=None, init=False)
     pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
+    processing_new_time: bool = False
 
+    fsm_config: FSMConfig | None = None
     fsm: FSM[ConnectedModel, Message] = field(init=False)
 
     def __post_init__(self):
@@ -171,7 +173,7 @@ class ConnectedModel:
                 f"Total time spent in in model '{self.name}': {s:.1f} seconds "
             ),
         )
-        self.fsm = FSM(Registration, self, raise_on_done=False)
+        self.fsm = FSM(self.fsm_config or MODEL_FSM_CONFIG, self, raise_on_done=False)
         self.fsm.start()
 
     def recv_event(self, event: Message):
@@ -193,15 +195,6 @@ class ConnectedModel:
 class BaseModelState(State[ConnectedModel], ABC):
     valid_commands: t.Tuple[t.Type[Command], ...] = ()
     valid_responses: t.Tuple[t.Type[Response], ...] = ()
-    next_state: t.Type[BaseModelState] = None
-
-    def transitions(self) -> TransitionsT:
-        if self.next_state is not None:
-            return [(Always, self.next_state)]
-        return self._transitions()
-
-    def _transitions(self):
-        return []
 
 
 class WaitingForMessage(BaseModelState):
@@ -300,7 +293,6 @@ class WaitingForMessage(BaseModelState):
         if not self.context.quit:
             self.context.quit = QuitMessage()
             self.context.pending_updates = []
-            self.next_state = ProcessPendingQuit
 
     def notify_subscribers(self, command: t.Optional[Command] = None):
         command = command or NoUpdateMessage()
@@ -316,16 +308,14 @@ class Idle(WaitingForMessage):
 
     def process_new_time(self, msg: NewTimeMessage):
         self.context.ack = False
+        self.context.processing_new_time = True
         self.context.send_command(msg)
-        self.next_state = NewTime
 
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
-        self.next_state = ProcessPendingUpdates
 
     def process_quit(self, msg: QuitMessage):
         self.context.quit = msg
-        self.next_state = ProcessPendingQuit
 
 
 class Busy(WaitingForMessage):
@@ -342,14 +332,6 @@ class Busy(WaitingForMessage):
 
     def process_quit(self, msg: QuitMessage):
         self.context.quit = msg
-
-    def _transitions(self):
-        return [
-            (lambda c: c.failed, Done),
-            (lambda c: (not c.busy) and c.quit, ProcessPendingQuit),
-            (lambda c: (not c.busy) and c.pending_updates, ProcessPendingUpdates),
-            (lambda c: not c.busy, Idle),
-        ]
 
 
 class Registration(Busy):
@@ -368,6 +350,9 @@ class NewTime(Busy):
 
     valid_commands = (UpdateMessage, NoUpdateMessage, QuitMessage)
     valid_responses = (AcknowledgeMessage, ErrorMessage)
+
+    def on_enter(self):
+        self.context.processing_new_time = False
 
 
 class Updating(Busy):
@@ -388,9 +373,6 @@ class PendingMoreUpdates(Idle):
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
 
-    def _transitions(self):
-        return [(Always, ProcessPendingUpdates)]
-
 
 class ProcessPendingUpdates(BaseModelState):
     """While the model was Busy, one or more updates came in which needs to be processed, this
@@ -406,11 +388,9 @@ class ProcessPendingUpdates(BaseModelState):
             )
 
         if any(model.busy for model in self.context.subscribed_to):
-            self.next_state = PendingMoreUpdates
             return
 
         self.process_pending_updates()
-        self.next_state = Updating
 
     def process_pending_updates(self):
         updates = self.context.pending_updates
@@ -432,7 +412,6 @@ class ProcessPendingQuit(BaseModelState):
             )
         self.context.ack = False
         self.context.send_command(self.context.quit)
-        self.next_state = Finalizing
 
 
 class Finalizing(Busy):
@@ -444,11 +423,6 @@ class Finalizing(Busy):
 
     def process_command(self, msg: Command):
         pass
-
-    def _transitions(self):
-        return [
-            (lambda c: not c.busy, Done),
-        ]
 
 
 class Done(BaseModelState):
@@ -493,3 +467,87 @@ class ModelCollection(dict[bytes, ConnectedModel]):
     def reset_model_timers(self):
         for model in self.values():
             model.timer.reset()
+
+
+class ModelHasFailed(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return self.context.failed
+
+
+class HasMisbehaved(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.failed and self.context.quit)
+
+
+class HasPendingQuit(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.quit)
+
+
+class HasPendingQuitAndIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return (not self.context.busy) and bool(self.context.quit)
+
+
+class HasPendingUpdates(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.pending_updates)
+
+
+class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool((not self.context.busy) and self.context.pending_updates)
+
+
+class IsIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return not self.context.busy
+
+
+class IsProcessingNewTime(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return self.context.processing_new_time
+
+
+class ModelWaitingForDependencies(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return any(model.busy for model in self.context.subscribed_to)
+
+
+# after invalid: a model should always process quit
+# When a model is busy and it receives a quit, it should not process it yet and stay in its own
+MODEL_BUSY_TRANSITIONS = (
+    (HasMisbehaved, ProcessPendingQuit),
+    (HasPendingQuitAndIdle, ProcessPendingQuit),
+    (ModelHasFailed, Done),
+    (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
+    (IsIdle, Idle),
+)
+
+MODEL_FSM_CONFIG = FSMConfig(
+    initial_state=Registration,
+    states={
+        Registration: MODEL_BUSY_TRANSITIONS,
+        NewTime: MODEL_BUSY_TRANSITIONS,
+        Updating: MODEL_BUSY_TRANSITIONS,
+        Idle: [
+            (HasPendingQuit, ProcessPendingQuit),
+            (HasPendingUpdates, ProcessPendingUpdates),
+            (IsProcessingNewTime, NewTime),
+        ],
+        ProcessPendingUpdates: [
+            (ModelWaitingForDependencies, PendingMoreUpdates),
+            (Always, Updating),
+        ],
+        PendingMoreUpdates: [
+            (Always, ProcessPendingUpdates),
+        ],
+        ProcessPendingQuit: [
+            (Always, Finalizing),
+        ],
+        Finalizing: [
+            (IsIdle, Done),
+        ],
+        Done: [],
+    },
+)

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -174,6 +174,8 @@ class ConnectedModel:
             ),
         )
         self.fsm = FSM(self.fsm_config or MODEL_FSM_CONFIG, self, raise_on_done=False)
+
+    def start(self):
         self.fsm.start()
 
     def recv_event(self, event: Message):
@@ -182,12 +184,10 @@ class ConnectedModel:
     def send_command(self, message: Command) -> None:
         """Send a message and start the timer. Also, start waiting"""
         self.send(message)
-        self.timer.start()
-        self.busy = True
 
     def log_invalid(self, message, valid_messages: t.Iterable[t.Type[Message]]):
         self.logger.error(
-            f"Received invalid message {message} from model '{self.name}'. Expected one of "
+            f"Received invalid message in {message} from model '{self.name}'. Expected one of "
             + ", ".join(m.__name__ for m in valid_messages)
         )
 
@@ -214,8 +214,10 @@ class WaitingForMessage(BaseModelState):
 
     def process_command(self, msg: Command):
         if not isinstance(msg, self.valid_commands):
-            self.handle_invalid(msg, self.valid_commands)
-            return
+            raise ValueError(
+                f"Received invalid command {msg} for model '{self.context.name}'. Expected one of "
+                + ", ".join(m.__name__ for m in self.valid_commands)
+            )
 
         if isinstance(msg, NewTimeMessage):
             self.process_new_time(msg)
@@ -232,7 +234,7 @@ class WaitingForMessage(BaseModelState):
         self.context.busy = False
 
         if not isinstance(msg, self.valid_responses):
-            self.handle_invalid(msg, self.valid_responses)
+            self.handle_invalid_response(msg, self.valid_responses)
         else:
             self._handle_response(msg)
 
@@ -287,9 +289,9 @@ class WaitingForMessage(BaseModelState):
         self.context.quit = None
         self.context.pending_updates = []
 
-    def handle_invalid(self, msg: Message, valid_messages: t.Iterable[t.Type[Message]]):
-        self.context.log_invalid(msg, valid_messages)
+    def handle_invalid_response(self, msg: Message, valid_messages: t.Iterable[t.Type[Message]]):
         self.context.failed = True
+        self.context.log_invalid(msg, valid_messages)
         if not self.context.quit:
             self.context.quit = QuitMessage()
             self.context.pending_updates = []
@@ -327,6 +329,10 @@ class Busy(WaitingForMessage):
     valid_commands = (UpdateMessage, NoUpdateMessage, QuitMessage)
     valid_responses = (ErrorMessage,)
 
+    def on_enter(self):
+        self.context.busy = True
+        self.context.timer.start()
+
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
 
@@ -340,10 +346,6 @@ class Registration(Busy):
     valid_commands = (QuitMessage,)
     valid_responses = (RegistrationMessage, ErrorMessage)
 
-    def on_enter(self):
-        self.context.busy = True
-        self.context.timer.start()
-
 
 class NewTime(Busy):
     """A NewTime message has been sent to the model, and it needs to Acknowledge that"""
@@ -352,6 +354,7 @@ class NewTime(Busy):
     valid_responses = (AcknowledgeMessage, ErrorMessage)
 
     def on_enter(self):
+        super().on_enter()
         self.context.processing_new_time = False
 
 
@@ -474,34 +477,14 @@ class ModelHasFailed(Condition[ConnectedModel]):
         return self.context.failed
 
 
-class HasMisbehaved(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.failed and self.context.quit)
-
-
-class HasPendingQuit(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.quit)
-
-
 class HasPendingQuitAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return (not self.context.busy) and bool(self.context.quit)
-
-
-class HasPendingUpdates(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.pending_updates)
+        return bool(self.context.quit and not self.context.busy)
 
 
 class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return bool((not self.context.busy) and self.context.pending_updates)
-
-
-class IsIdle(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return not self.context.busy
+        return bool(self.context.pending_updates and not self.context.busy)
 
 
 class IsProcessingNewTime(Condition[ConnectedModel]):
@@ -509,15 +492,17 @@ class IsProcessingNewTime(Condition[ConnectedModel]):
         return self.context.processing_new_time
 
 
+class IsIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return not self.context.busy
+
+
 class ModelWaitingForDependencies(Condition[ConnectedModel]):
     def met(self) -> bool:
         return any(model.busy for model in self.context.subscribed_to)
 
 
-# after invalid: a model should always process quit
-# When a model is busy and it receives a quit, it should not process it yet and stay in its own
 MODEL_BUSY_TRANSITIONS = (
-    (HasMisbehaved, ProcessPendingQuit),
     (HasPendingQuitAndIdle, ProcessPendingQuit),
     (ModelHasFailed, Done),
     (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
@@ -531,8 +516,8 @@ MODEL_FSM_CONFIG = FSMConfig(
         NewTime: MODEL_BUSY_TRANSITIONS,
         Updating: MODEL_BUSY_TRANSITIONS,
         Idle: [
-            (HasPendingQuit, ProcessPendingQuit),
-            (HasPendingUpdates, ProcessPendingUpdates),
+            (HasPendingQuitAndIdle, ProcessPendingQuit),
+            (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
             (IsProcessingNewTime, NewTime),
         ],
         ProcessPendingUpdates: [

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -21,7 +21,7 @@ from movici_simulation_core.messages import (
 from movici_simulation_core.utils.data_mask import masks_overlap
 
 from .fsm import FSM, Always, State, TransitionsT
-from .interconnectivity import format_matrix
+from .interconnectivity import Publisher, format_matrix
 from .stopwatch import ReportingStopwatch, Stopwatch
 
 
@@ -48,6 +48,22 @@ class Context:
     def log_new_phase(self, phase: str):
         self.logger.info(f"Entering {phase}")
 
+    def queue_models_for_next_time(self):
+        next_time = self.models.next_time
+        if next_time is None:
+            raise RuntimeError(
+                "Cannot progress to next time when all models are done,"
+                " should finalize simulation instead"
+            )
+
+        if next_time != self.timeline.current_time:
+            self.timeline.current_time = next_time
+            self.models.queue_all(NewTimeMessage(next_time))
+
+        for model in self.models.values():
+            if model.next_time == next_time:
+                model.recv_event(UpdateMessage(timestamp=next_time))
+
     def log_new_time(self):
         if self.models.next_time != self.timeline.current_time:
             self.logger.info(f"New time: {self.models.next_time}")
@@ -59,7 +75,10 @@ class Context:
         self.logger.info(f"Total elapsed time: {seconds:.1f}")
 
     def log_interconnectivity_matrix(self):
-        self.logger.info("Model interconnectivity matrix:\n" + format_matrix(self.models.values()))
+        self.logger.info(
+            "Model interconnectivity matrix:\n"
+            + format_matrix(t.cast(list[Publisher], list(self.models.values())))
+        )
 
     def finalize(self):
         self.phase_timer.reset()
@@ -85,7 +104,7 @@ class Context:
 class TimelineController:
     start: int
     end: int
-    current_time: int = None
+    current_time: int | None = None
 
     def set_model_to_start(self, model: ConnectedModel):
         model.next_time = self.start
@@ -103,13 +122,6 @@ class TimelineController:
             return None
 
         return min(next_time, self.end)
-
-    def queue_for_next_time(self, models: ModelCollection):
-        next_time = models.next_time
-        if next_time != self.current_time:
-            self.current_time = next_time
-            models.queue_all(NewTimeMessage(next_time))
-        models.queue_models_for_next_time()
 
 
 class NoUpdateMessage(Message):
@@ -134,11 +146,11 @@ class ConnectedModel:
     send: t.Callable[[Message], None]
 
     logger: logging.Logger = field(default_factory=logging.getLogger)
-    publishes_to: t.Optional[t.List[ConnectedModel]] = field(default_factory=list)
-    subscribed_to: t.Optional[t.List[ConnectedModel]] = field(default_factory=list)
-    timer: Stopwatch = field(default=None)
-    pub: t.Optional[dict] = field(default_factory=dict)
-    sub: t.Optional[dict] = field(default_factory=dict)
+    publishes_to: list[ConnectedModel] = field(default_factory=list)
+    subscribed_to: list[ConnectedModel] = field(default_factory=list)
+    timer: Stopwatch = field(init=False)
+    pub: dict | None = field(default_factory=dict)
+    sub: dict | None = field(default_factory=dict)
 
     busy: bool = field(default=False, init=False)
     next_time: t.Optional[int] = field(default=None, init=False)
@@ -148,10 +160,10 @@ class ConnectedModel:
     quit: t.Optional[QuitMessage] = field(default=None, init=False)
     pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
 
-    fsm: FSM[ConnectedModel] = field(init=False)
+    fsm: FSM[ConnectedModel, Message] = field(init=False)
 
     def __post_init__(self):
-        self.timer = self.timer or ReportingStopwatch(
+        self.timer = ReportingStopwatch(
             on_stop=lambda s: self.logger.debug(
                 f"Model '{self.name}' returned in {s:.1f} seconds "
             ),
@@ -418,12 +430,9 @@ class ProcessPendingQuit(BaseModelState):
             raise RuntimeError(
                 "can only enter ProcessPendingQuit when there is a QuitMessage pending"
             )
-        self.process_pending_quit()
-        self.next_state = Finalizing
-
-    def process_pending_quit(self):
         self.context.ack = False
         self.context.send_command(self.context.quit)
+        self.next_state = Finalizing
 
 
 class Finalizing(Busy):
@@ -449,7 +458,7 @@ class Done(BaseModelState):
         yield
 
 
-class ModelCollection(dict, t.Dict[bytes, ConnectedModel]):
+class ModelCollection(dict[bytes, ConnectedModel]):
     @property
     def busy(self):
         return any(model.busy for model in self.values())
@@ -473,13 +482,6 @@ class ModelCollection(dict, t.Dict[bytes, ConnectedModel]):
         """add a message to the queue of all models"""
         for model in self.values():
             model.recv_event(message)
-
-    def queue_models_for_next_time(self):
-        """Queue an update message to the model(s) that have the specified next_time"""
-        next_time = self.next_time
-        for model in self.values():
-            if model.next_time == next_time:
-                model.recv_event(UpdateMessage(timestamp=next_time))
 
     def determine_interdependency(self):
         """calculate the subscribers for every model based on the pub/sub mask."""

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -18,17 +18,17 @@ def send_silent(coro: t.Generator, value: t.Any):
         pass
 
 
-def fsm_conditional_raise(func=None, attribute: str = None, exc: t.Type[Exception] = None):
-    if func is None:
-        return functools.partial(fsm_conditional_raise, attribute=attribute, exc=exc)
+def fsm_conditional_raise(attribute: str, exc: t.Type[Exception]):
+    def _decorator(func):
+        @functools.wraps(func)
+        def wrapper(fsm: FSM, *args, **kwargs):
+            if getattr(fsm, attribute):
+                raise exc()
+            return func(fsm, *args, **kwargs)
 
-    @functools.wraps(func)
-    def wrapper(fsm: FSM, *args, **kwargs):
-        if getattr(fsm, attribute):
-            raise exc()
-        return func(fsm, *args, **kwargs)
+        return wrapper
 
-    return wrapper
+    return _decorator
 
 
 not_started = fsm_conditional_raise(attribute="started", exc=FSMStarted)
@@ -70,6 +70,7 @@ class FSM(t.Generic[T, E]):
 
     @not_done
     def send(self, event: E):
+        assert self.runner is not None
         send_silent(self.runner, event)
 
     def transition(self):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -93,6 +93,7 @@ class FSM(t.Generic[T, E]):
 
     def _run(self):
         try:
+            self.state.on_enter()
             while True:
                 if inspect.isgeneratorfunction(self.state.run):
                     yield from self.state.run()
@@ -115,6 +116,7 @@ class FSM(t.Generic[T, E]):
     def transition(self):
         if new_state := next_state(self.context, self.config.states.get(type(self.state), [])):
             self.state = new_state(self.context)
+            self.state.on_enter()
 
 
 def next_state(context, transitions: TransitionsT):
@@ -131,7 +133,6 @@ class Event:
 class State(ABC, t.Generic[T]):
     def __init__(self, context: T):
         self.context = context
-        self.on_enter()
 
     def on_enter(self):
         pass

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import inspect
+import itertools
 import typing as t
 from abc import ABC, abstractmethod
 
@@ -35,10 +37,47 @@ not_started = fsm_conditional_raise(attribute="started", exc=FSMStarted)
 not_done = fsm_conditional_raise(attribute="done", exc=FSMDone)
 
 
+@dataclasses.dataclass
+class FSMConfig(t.Generic[T]):
+    """A config for setting up a :class:`FSM` final state machine
+
+    :param initial_state: the initial state
+    :param states: a dictionary of all possible states as ``type``s and their transitions.
+        Transitions are a sequence of ``(type[Condition], type[State])`` tuples
+    :pararm strict: a boolean whether to validate that all states mentioned in the transitions
+        and ``initial`` state must have an entry in the states  dictionary
+    """
+
+    initial_state: type[State[T]]
+    states: dict[type[State[T]], TransitionsT] = dataclasses.field(default_factory=dict)
+    strict: bool = True
+
+    def __post_init__(self):
+        if not self.strict:
+            return
+        if self.initial_state not in self.states:
+            raise ValueError(
+                f"'initial_state' {self.initial_state.__name__} is not a member of 'states' "
+                "and 'strict' was set"
+            )
+        for _, state in itertools.chain.from_iterable(self.states.values()):
+            if state not in self.states:
+                raise ValueError(
+                    f"State {state.__name__} was mentioned in a transition but it is not a member"
+                    "of 'states' and 'strict' was set"
+                )
+
+
 class FSM(t.Generic[T, E]):
-    def __init__(self, initial_state: t.Type[State], context: T = None, raise_on_done=True):
+    def __init__(
+        self,
+        config: FSMConfig[T],
+        context: T = None,
+        raise_on_done=True,
+    ):
         self.context = context
-        self.state = initial_state(context=self.context)
+        self.config = config
+        self.state = config.initial_state(context=self.context)
         self.runner = None
         self.started = False
         self.done = False
@@ -74,13 +113,13 @@ class FSM(t.Generic[T, E]):
         send_silent(self.runner, event)
 
     def transition(self):
-        if new_state := next_state(self.state):
+        if new_state := next_state(self.context, self.config.states.get(type(self.state), [])):
             self.state = new_state(self.context)
 
 
-def next_state(state: State) -> t.Optional[t.Type[State]]:
-    for cond, new_state in state.transitions():
-        if cond(state.context):
+def next_state(context, transitions: TransitionsT):
+    for cond, new_state in transitions:
+        if cond(context):
             return new_state
     return None
 
@@ -122,4 +161,4 @@ class Always(Condition):
         return True
 
 
-TransitionsT = t.List[t.Tuple[t.Type[Condition], t.Type[State]]]
+TransitionsT = t.Sequence[tuple[type[Condition], type[State]]]

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/interconnectivity.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/interconnectivity.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import typing as t
 
 
-class IPubSubFilter(t.Protocol):
+class Publisher(t.Protocol):
     name: str
-    pub: dict
-    sub: dict
-    subscribers: t.List[IPubSubFilter]
+    publishes_to: t.List[Publisher]
 
 
-def format_matrix(models: t.Sequence[IPubSubFilter], title="", match="X"):
+def format_matrix(models: t.Sequence[Publisher], title="", match="X"):
     """
     ::
 
@@ -28,7 +26,7 @@ def format_matrix(models: t.Sequence[IPubSubFilter], title="", match="X"):
     def header_row():
         return first_column(title) + "".join(box(num) for num in model_nums.values())
 
-    def model_row(model):
+    def model_row(model: Publisher):
         return first_column(box(model_nums[model.name]) + model.name) + "".join(
             box(match if sub in model.publishes_to else "") for sub in models
         )

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -96,12 +96,14 @@ class Orchestrator(Service):
         self.stream.set_handler(self.fsm.send)
 
     def _get_connected_model(self, identifier: str):
-        return ConnectedModel(
+        model = ConnectedModel(
             name=identifier,
             timeline=self.timeline,
             send=self.make_send(identifier),
             logger=self.logger,
         )
+        model.start()
+        return model
 
     def make_send(self, identifier: str):
         """create a send function that a can be used to send a message to a specific client

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -8,7 +8,7 @@ from movici_simulation_core.services.orchestrator.context import ConnectedModel,
 from movici_simulation_core.settings import Settings
 from movici_simulation_core.simulation import Simulation
 
-from .context import Context, TimelineController
+from .context import MODEL_FSM_CONFIG, Context, TimelineController
 from .fsm import FSM, Always, FSMConfig, FSMDone
 from .states import (
     AllModelsDone,
@@ -101,6 +101,7 @@ class Orchestrator(Service):
             timeline=self.timeline,
             send=self.make_send(identifier),
             logger=self.logger,
+            fsm_config=MODEL_FSM_CONFIG,
         )
         model.start()
         return model

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -9,8 +9,52 @@ from movici_simulation_core.settings import Settings
 from movici_simulation_core.simulation import Simulation
 
 from .context import Context, TimelineController
-from .fsm import FSM, FSMDone
-from .states import StartInitializingPhase
+from .fsm import FSM, Always, FSMConfig, FSMDone
+from .states import (
+    AllModelsDone,
+    AllModelsReady,
+    EndFinalizingPhase,
+    Failed,
+    FinalizingWaitForModels,
+    ModelsRegistration,
+    NewTime,
+    StartFinalizingPhase,
+    StartInitializingPhase,
+    StartRunningPhase,
+    WaitForResults,
+)
+
+FSM_CONFIG = FSMConfig(
+    initial_state=StartInitializingPhase,
+    states={
+        StartInitializingPhase: [
+            (Always, ModelsRegistration),
+        ],
+        ModelsRegistration: [
+            (Failed, StartFinalizingPhase),
+            (AllModelsReady, StartRunningPhase),
+        ],
+        StartRunningPhase: [
+            (Always, NewTime),
+        ],
+        NewTime: [
+            (Always, WaitForResults),
+        ],
+        WaitForResults: [
+            (Failed, StartFinalizingPhase),
+            (AllModelsDone, StartFinalizingPhase),
+            (AllModelsReady, NewTime),
+        ],
+        StartFinalizingPhase: [
+            (AllModelsReady, EndFinalizingPhase),
+            (Always, FinalizingWaitForModels),
+        ],
+        FinalizingWaitForModels: [
+            (AllModelsReady, EndFinalizingPhase),
+        ],
+        EndFinalizingPhase: [],
+    },
+)
 
 
 class Orchestrator(Service):
@@ -48,7 +92,7 @@ class Orchestrator(Service):
         )
 
     def _setup_fsm(self):
-        self.fsm = FSM(StartInitializingPhase, context=self.context)
+        self.fsm = FSM(FSM_CONFIG, context=self.context)
         self.stream.set_handler(self.fsm.send)
 
     def _get_connected_model(self, identifier: str):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from abc import ABC
 
 from movici_simulation_core.messages import QuitMessage
@@ -43,7 +44,7 @@ class StartInitializingPhase(OrchestratorState):
         self.context.phase_timer.start()
         self.context.log_new_phase("Initializing Phase")
 
-    def transitions(self):
+    def transitions(self) -> TransitionsT:
         return [(Always, ModelsRegistration)]
 
 
@@ -51,7 +52,7 @@ class WaitForModels(OrchestratorState, ABC):
     def run(self):
         ident, msg = yield
 
-        if not (model := self.context.models.get(ident)):
+        if not (model := self.context.models.get(t.cast(bytes, ident))):
             return
         model.recv_event(msg)
 
@@ -78,7 +79,7 @@ class StartRunningPhase(OrchestratorState):
 class NewTime(OrchestratorState):
     def run(self):
         self.context.log_new_time()
-        self.context.timeline.queue_for_next_time(self.context.models)
+        self.context.queue_models_for_next_time()
 
     def transitions(self) -> TransitionsT:
         return [(Always, WaitForResults)]

--- a/packages/simulation-core/src/movici_simulation_core/utils/data_mask.py
+++ b/packages/simulation-core/src/movici_simulation_core/utils/data_mask.py
@@ -22,7 +22,6 @@ def validate_mask(data_mask: t.Optional[dict]):
         if df is None:
             return True
 
-        # noinspection PyTypeHints
         if not len(df) or not isinstance(df, shape[depth]):
             return False
         if isinstance(df, dict):
@@ -56,7 +55,7 @@ def ensure_id(mask: t.List[str]):
 
 def masks_overlap(pub: t.Optional[dict], sub: t.Optional[dict]):
     """calculates whether there is overlap between the pub and sub filters of two models. This
-    function assumes that the two filters have been validated using `validate_filter`
+    function assumes that the two filters have been validated using `validate_mask`
     """
     if pub == {} or sub == {}:
         return False

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -13,6 +13,8 @@ from movici_simulation_core.messages import (
     UpdateMessage,
 )
 from movici_simulation_core.services.orchestrator.context import (
+    MODEL_BUSY_TRANSITIONS,
+    MODEL_FSM_CONFIG,
     BaseModelState,
     Busy,
     ConnectedModel,
@@ -25,7 +27,7 @@ from movici_simulation_core.services.orchestrator.context import (
     Updating,
     WaitingForMessage,
 )
-from movici_simulation_core.services.orchestrator.fsm import next_state
+from movici_simulation_core.services.orchestrator.fsm import next_state as next_state_
 
 
 @pytest.fixture
@@ -45,18 +47,29 @@ def state(context, state_cls):
 
 @pytest.fixture
 def send_message(state, context):
-    runner = state.run()
-    runner.send(None)
 
     def _send(msg: Message):
-        nonlocal runner
+        runner = state.run()
+        runner.send(None)
         try:
             runner.send(msg)
         except StopIteration:
-            runner = state.run()
-            runner.send(None)
+            pass
 
     return _send
+
+
+@pytest.fixture
+def transitions(state_cls):
+    return MODEL_FSM_CONFIG.states[state_cls]
+
+
+@pytest.fixture
+def next_state(context, transitions):
+    def _calculate_next_state():
+        return next_state_(context, transitions)
+
+    return _calculate_next_state
 
 
 class TestWaitingForMessage:
@@ -84,9 +97,65 @@ class TestWaitingForMessage:
         send_message(msg)
         assert context.failed
 
-    def test_goes_to_process_quit_after_invalid_message(self, send_message, state):
+
+class TestBusyTransitions:
+    @pytest.fixture
+    def state_cls(self):
+        # Use NewTime as a substitute for Busy state, since it has an implementation for a model
+        # response (AcknowledgeMessage)
+        return NewTime
+
+    @pytest.fixture
+    def transitions(self):
+        return MODEL_BUSY_TRANSITIONS
+
+    @pytest.fixture
+    def state(self, state_cls, context):
+        state = state_cls(context)
+        state.on_enter()
+        return state
+
+    @pytest.fixture
+    def send_message(self, state):
+        def _send(msg: Message):
+            runner = state.run()
+            runner.send(None)
+            try:
+                runner.send(msg)
+            except StopIteration:
+                pass
+
+        return _send
+
+    def test_transitions_after_invalid_message(self, send_message, next_state):
         send_message(NewTimeMessage(1))
-        assert next_state(state) == ProcessPendingQuit
+        assert next_state() == ProcessPendingQuit
+
+    def test_transitions_after_error_message(self, send_message, next_state):
+        send_message(ErrorMessage())
+        assert next_state() == Done
+
+    def test_transitions_to_idle_when_no_pending_messages(self, send_message, context, next_state):
+        assert not context.quit
+        assert not context.pending_updates
+        send_message(AcknowledgeMessage())
+        assert next_state() == Idle
+
+    def test_transitions_on_pending_updates(self, send_message, next_state):
+        send_message(UpdateMessage(1))
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingUpdates
+
+    def test_transitions_on_pending_quit(self, send_message, next_state):
+        send_message(QuitMessage())
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingQuit
+
+    def test_quit_has_preference_over_updates(self, send_message, next_state):
+        send_message(QuitMessage())
+        send_message(UpdateMessage(1))
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingQuit
 
 
 class TestIdle:
@@ -117,9 +186,9 @@ class TestIdle:
             (QuitMessage(), ProcessPendingQuit),
         ],
     )
-    def test_transitions_to_correct_state(self, msg, expected, send_message, state):
+    def test_transitions_to_correct_state(self, msg, expected, send_message, next_state):
         send_message(msg)
-        assert next_state(state) == expected
+        assert next_state() == expected
 
 
 class TestBusy:
@@ -148,45 +217,6 @@ class TestBusy:
         send_message(ErrorMessage())
         assert not context.quit
         assert not context.pending_updates
-
-
-class TestBusyTransitions:
-    @pytest.fixture
-    def state_cls(self):
-        # Use NewTime as a substitute for Busy state, since it has an implementation for a model
-        # response (AcknowledgeMessage)
-        return NewTime
-
-    @pytest.fixture
-    def context(self, context):
-        context.busy = True
-        return context
-
-    def test_transitions_after_error_message(self, send_message, state):
-        send_message(ErrorMessage())
-        assert next_state(state) == Done
-
-    def test_transitions_to_idle_when_no_pending_messages(self, send_message, state, context):
-        assert not context.quit
-        assert not context.pending_updates
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == Idle
-
-    def test_transitions_on_pending_updates(self, send_message, state, context):
-        send_message(UpdateMessage(1))
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingUpdates
-
-    def test_transitions_on_pending_quit(self, send_message, state, context):
-        send_message(QuitMessage())
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingQuit
-
-    def test_quit_has_preference_over_updates(self, send_message, state, context):
-        send_message(QuitMessage())
-        send_message(UpdateMessage(1))
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingQuit
 
 
 @pytest.mark.parametrize(

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -84,18 +84,19 @@ class TestWaitingForMessage:
     @pytest.mark.parametrize(
         "msg",
         [
-            NewTimeMessage(1),
-            UpdateMessage(1),
-            QuitMessage(),
             RegistrationMessage(pub=None, sub=None),
             AcknowledgeMessage(),
             ResultMessage(),
             ErrorMessage(),
         ],
     )
-    def test_invalid_message_sets_failed(self, msg, send_message, context):
+    def test_invalid_response_sets_failed(self, msg, send_message, context):
         send_message(msg)
         assert context.failed
+
+    def test_invalid_command_raises(self, send_message):
+        with pytest.raises(ValueError):
+            send_message(NewTimeMessage(1))
 
 
 class TestBusyTransitions:
@@ -127,8 +128,8 @@ class TestBusyTransitions:
 
         return _send
 
-    def test_transitions_after_invalid_message(self, send_message, next_state):
-        send_message(NewTimeMessage(1))
+    def test_transitions_after_invalid_response(self, send_message, next_state):
+        send_message(ResultMessage())
         assert next_state() == ProcessPendingQuit
 
     def test_transitions_after_error_message(self, send_message, next_state):
@@ -195,6 +196,11 @@ class TestBusy:
     @pytest.fixture
     def state_cls(self):
         return Busy
+
+    def test_on_enter_starts_timer(self, context: ConnectedModel):
+        assert not context.timer.running
+        Busy(context).on_enter()
+        assert context.timer.running
 
     def test_sets_quit_message_as_pending(self, send_message, context):
         assert context.quit is None

--- a/packages/simulation-core/tests/services/orchestrator/test_connected_model.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_connected_model.py
@@ -18,7 +18,9 @@ def timeline():
 
 def get_model(name="dummy", timeline=None, send=None, **kwargs):
     send = send or Mock()
-    return ConnectedModel(name, timeline, send, **kwargs)
+    model = ConnectedModel(name, timeline, send, **kwargs)
+    model.start()
+    return model
 
 
 class TestConnectedModel:
@@ -63,14 +65,6 @@ class TestConnectedModel:
         msg = UpdateMessage(1)
         model.recv_event(msg)
         assert model.send.call_args == call(msg)
-
-    def test_send_command_starts_timer(self, model):
-        model.send_command(UpdateMessage(1))
-        assert model.timer.running
-
-    def test_send_command_marks_model_as_waiting(self, model):
-        model.send_command(UpdateMessage(1))
-        assert model.busy
 
     def test_response_stops_timer_and_busy(self, running_model):
         running_model.recv_event(ResultMessage())

--- a/packages/simulation-core/tests/services/orchestrator/test_context.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_context.py
@@ -4,6 +4,7 @@ import pytest
 
 from movici_simulation_core.messages import NewTimeMessage, UpdateMessage
 from movici_simulation_core.services.orchestrator.context import (
+    Context,
     ModelCollection,
     TimelineController,
 )
@@ -49,26 +50,30 @@ class TestTimelineController:
         timeline = TimelineController(start=1, end=20, current_time=10)
         assert timeline._get_validated_next_time(10) == 10
 
+
+class TestContext:
     @pytest.mark.parametrize(
         "next_a, next_b, exp_a, exp_b",
         [
             (0, 1, [UpdateMessage(0)], []),
             (2, 1, [NewTimeMessage(1)], [NewTimeMessage(1), UpdateMessage(1)]),
             (1, 2, [NewTimeMessage(1), UpdateMessage(1)], [NewTimeMessage(1)]),
+            (2, 2, [NewTimeMessage(2), UpdateMessage(2)], [NewTimeMessage(2), UpdateMessage(2)]),
             (2, None, [NewTimeMessage(2), UpdateMessage(2)], [NewTimeMessage(2)]),
             (None, 2, [NewTimeMessage(2)], [NewTimeMessage(2), UpdateMessage(2)]),
         ],
     )
     def test_queue_for_next_time(self, next_a, next_b, exp_a, exp_b):
-        timeline = TimelineController(start=0, end=20, current_time=0)
         a, b = Mock(), Mock()
-        models = ModelCollection(
-            a=a,
-            b=b,
+
+        context = Context(
+            models=ModelCollection(a=a, b=b),
+            timeline=TimelineController(start=0, end=20, current_time=0),
         )
         a.next_time = next_a
         b.next_time = next_b
 
-        timeline.queue_for_next_time(models)
+        context.queue_models_for_next_time()
+
         assert a.recv_event.call_args_list == [call(msg) for msg in exp_a]
         assert b.recv_event.call_args_list == [call(msg) for msg in exp_b]

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -61,6 +61,29 @@ def test_calls_on_enter_when_starting():
     assert StateA.on_enter.call_count == 1
 
 
+def test_calls_on_enter_when_transitioning():
+    class StateA(DummyState):
+        pass
+
+    class StateB(DummyState):
+        on_enter = Mock()
+        is_final = True
+
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
+    fsm.start()
+    assert StateB.on_enter.call_count == 1
+
+
 def test_fsm_runs_a_state():
     class StateA(DummyState):
         is_final = True

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -9,8 +9,8 @@ from movici_simulation_core.services.orchestrator.fsm import (
     Always,
     Condition,
     Event,
+    FSMConfig,
     State,
-    TransitionsT,
 )
 
 
@@ -52,7 +52,11 @@ def test_calls_on_enter_when_starting():
         is_final = True
         on_enter = Mock()
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(initial_state=StateA, states={StateA: []}),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert StateA.on_enter.call_count == 1
 
@@ -61,28 +65,40 @@ def test_fsm_runs_a_state():
     class StateA(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(initial_state=StateA, states={StateA: []}),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA]
 
 
 def test_fsm_does_a_transition():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA, StateB]
 
 
 def test_fsm_calls_on_enter_on_transition():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(DummyState):
         is_final = True
@@ -90,7 +106,17 @@ def test_fsm_calls_on_enter_on_transition():
 
     assert StateA.on_enter is not StateB.on_enter
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert StateB.on_enter.call_count == 1
 
@@ -102,7 +128,16 @@ def test_fsm_doensnt_call_on_enter_when_not_transitioning():
             self.is_final = True
 
     context = DummyContext()
-    fsm = FSM(StateA, context=context, raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [],
+            },
+        ),
+        context=context,
+        raise_on_done=False,
+    )
     fsm.start()
     assert context.states == [StateA, StateA]
     assert StateA.on_enter.call_count == 1
@@ -113,7 +148,16 @@ def test_evented_state_handles_event():
         is_final = True
 
     event = Event()
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     fsm.send(event)
     assert fsm.context.events == [event]
@@ -121,13 +165,22 @@ def test_evented_state_handles_event():
 
 def test_fsm_runs_until_event_required():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(EventState):
         pass
 
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA]
     assert isinstance(fsm.state, StateB)
@@ -141,17 +194,31 @@ def test_fsm_does_more_complex_transitions():
             return StateB not in self.context.states
 
     class StateA(EventState):
-        def transitions(self) -> TransitionsT:
-            return [(HaventTransitionedToB, StateB), (Always, StateC)]
+        pass
 
     class StateB(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateA)]
+        pass
 
     class StateC(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            StateA,
+            states={
+                StateA: [
+                    (HaventTransitionedToB, StateB),
+                    (Always, StateC),
+                ],
+                StateB: [
+                    (Always, StateA),
+                ],
+                StateC: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     one = Event()
     two = Event()
@@ -166,7 +233,14 @@ def test_fsm_raises_when_trying_to_send_when_done():
     class DoneState(DummyState):
         is_final = True
 
-    fsm = FSM(DoneState, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            DoneState,
+            states={DoneState: []},
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     with pytest.raises(FSMDone):
         fsm.send(Event())
@@ -174,13 +248,22 @@ def test_fsm_raises_when_trying_to_send_when_done():
 
 def test_fsm_raises_when_trying_to_start_twice():
     class SomeState(EventState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, FinalState)]
+        pass
 
     class FinalState(DummyState):
         is_final = True
 
-    fsm = FSM(SomeState, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            SomeState,
+            states={
+                SomeState: [(Always, FinalState)],
+                FinalState: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
 
     with pytest.raises(FSMStarted):

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -97,9 +97,13 @@ class TestStartRunningPhase(BaseTestState):
 class TestNewTime(BaseTestState):
     state_cls = NewTime
 
+    @pytest.fixture
+    def context(self):
+        return Mock()
+
     def test_queues_models(self, state, context):
         state.run()
-        assert context.timeline.queue_for_next_time.call_args == call(context.models)
+        assert context.queue_models_for_next_time.call_count == 1
 
 
 class TestStartFinalizingPhase(BaseTestState):

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -18,7 +18,7 @@ from movici_simulation_core.services.orchestrator.states import (
 
 
 class BaseTestState:
-    state_cls = OrchestratorState
+    state_cls: type[OrchestratorState]
 
     @pytest.fixture
     def state(self, context):


### PR DESCRIPTION
Describe your changes
--------------------
In order to optimize the Orchestrator for a non-distributed runner (and potentially other run modes), we need to hook into the internals of the orchestrator FSMs. Currently the Orchestrator and ConnectedModel FSMs are hard coded, making it hard to change which states connect to each other. This PR decouples the transitions from the state classes and allows the FSM to be configured using an `FSMConfig` class that contains the states and the transition (conditions) between them.

Furthermore this PR

* improves typing
* refactors/simplifies/makes things more logical

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to
 re-/sublicense my contribution
