### PR TITLE
Make FSM composable so that we can customize for specific use cases

### DIFF
--- a/packages/simulation-core/src/movici_simulation_core/exceptions.py
+++ b/packages/simulation-core/src/movici_simulation_core/exceptions.py
@@ -14,7 +14,7 @@ class OrchestratorException(SimulationException):
     pass
 
 
-class InvalidCommand(SimulationException):
+class InvalidCommand(OrchestratorException):
     pass
 
 

--- a/packages/simulation-core/src/movici_simulation_core/exceptions.py
+++ b/packages/simulation-core/src/movici_simulation_core/exceptions.py
@@ -14,10 +14,6 @@ class OrchestratorException(SimulationException):
     pass
 
 
-class SimulationExit(OrchestratorException):
-    pass
-
-
 class InvalidCommand(SimulationException):
     pass
 

--- a/packages/simulation-core/src/movici_simulation_core/exceptions.py
+++ b/packages/simulation-core/src/movici_simulation_core/exceptions.py
@@ -18,6 +18,10 @@ class SimulationExit(OrchestratorException):
     pass
 
 
+class InvalidCommand(SimulationException):
+    pass
+
+
 class NotReady(SimulationException):
     pass
 

--- a/packages/simulation-core/src/movici_simulation_core/messages.py
+++ b/packages/simulation-core/src/movici_simulation_core/messages.py
@@ -116,6 +116,13 @@ class AcknowledgeMessage(Message):
 
 @dataclasses.dataclass
 class QuitMessage(Message):
+    """A message to indicate that we should stop the simulation. Allows models to gracefully
+    terminate.
+
+    :param due_to_failure: flag to indicate that a component has failed and that it is not a
+        regular shutdown
+    """
+
     due_to_failure: bool = False
 
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -278,16 +278,18 @@ class WaitingForMessage(BaseModelState):
 
     @_handle_response.register
     def _(self, msg: AcknowledgeMessage) -> None:
-        """when a model sends an accepted message, don't do extra logic"""
+        """when a model sends an acknowledge message, do nothing but notify subscribers that the
+        model has returned
+        """
         if not self.context.pending_updates:
-            self.notify_subscribers()
+            self.notify_subscribers(NoUpdateMessage())
 
     @_handle_response.register
     def _(self, msg: ResultMessage) -> None:
-        """When a result comes set the model's next_time and possibly add a message to the
-        subscribers queues"""
+        """When a result comes set the model's next_time and notify subscribers that this model
+        has returned, with possible data"""
         self.context.timeline.set_next_time(self.context, msg.next_time)
-        command = None
+        command = NoUpdateMessage()
         if msg.has_data:
             command = UpdateMessage(
                 timestamp=self.context.timeline.current_time,
@@ -311,9 +313,14 @@ class WaitingForMessage(BaseModelState):
             self.context.pending_quit = QuitMessage()
             self.context.pending_updates = []
 
-    def notify_subscribers(self, command: Command | None = None):
-        command = command or NoUpdateMessage()
+    def notify_subscribers(self, command: UpdateMessage | NoUpdateMessage):
+        """Notify subscribers that this ConnectedModel's model has returned."""
         for model in self.context.publishes_to:
+            # This method may technically raise InvalidCommand if any of the subscribed models
+            # does not accept an UpdateMessage or NoUpdateMessage, but the (default)
+            # ``ConnectedModel.fsm_config`` ensures that this cannot happen. In case of a custom
+            # ``fsm_config`` and this method raises ``InvalidCommand``, this is caught upstream by
+            # the orchestrator's ``Config``
             model.recv_event(command)
 
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from functools import singledispatchmethod
 from itertools import product
 
+from movici_simulation_core.exceptions import InvalidCommand
 from movici_simulation_core.messages import (
     AcknowledgeMessage,
     ErrorMessage,
@@ -32,6 +33,7 @@ class Context:
     global_timer: Stopwatch = field(default=None)
     phase_timer: Stopwatch = field(default=None)
     logger: logging.Logger = field(default_factory=logging.getLogger)
+    orchestrator_failed: bool = False
 
     def __post_init__(self):
         self.global_timer = self.global_timer or ReportingStopwatch(
@@ -43,7 +45,7 @@ class Context:
 
     @property
     def failed(self):
-        return self.models.failed
+        return self.orchestrator_failed or self.models.failed
 
     def log_new_phase(self, phase: str):
         self.logger.info(f"Entering {phase}")
@@ -58,11 +60,23 @@ class Context:
 
         if next_time != self.timeline.current_time:
             self.timeline.current_time = next_time
-            self.models.queue_all(NewTimeMessage(next_time))
+            self.recv_for_all(NewTimeMessage(next_time))
 
         for model in self.models.values():
             if model.next_time == next_time:
-                model.recv_event(UpdateMessage(timestamp=next_time))
+                self.recv_message(model, UpdateMessage(timestamp=next_time))
+
+    def recv_for_all(self, message: Message):
+        """Receive a Message for all models"""
+        for model in self.models.values():
+            self.recv_message(model, message)
+
+    def recv_message(self, model: ConnectedModel, message: Message):
+        try:
+            model.recv_event(message)
+        except InvalidCommand:
+            self.logger.exception("Error while sending command")
+            self.orchestrator_failed = True
 
     def log_new_time(self):
         if self.models.next_time != self.timeline.current_time:
@@ -213,7 +227,7 @@ class WaitingForMessage(BaseModelState):
 
     def process_command(self, msg: Command):
         if not isinstance(msg, self.valid_commands):
-            raise ValueError(
+            raise InvalidCommand(
                 f"Received invalid command {msg} for model '{self.context.name}'. Expected one of "
                 + ", ".join(m.__name__ for m in self.valid_commands)
             )
@@ -430,11 +444,6 @@ class ModelCollection(dict[bytes, ConnectedModel]):
     @property
     def failed(self):
         return [model.name for model in self.values() if model.failed]
-
-    def queue_all(self, message: Message):
-        """add a message to the queue of all models"""
-        for model in self.values():
-            model.recv_event(message)
 
     def determine_interdependency(self):
         """calculate the subscribers for every model based on the pub/sub mask."""

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -155,11 +155,10 @@ class ConnectedModel:
     busy: bool = field(default=False, init=False)
     next_time: t.Optional[int] = field(default=None, init=False)
     failed: bool = field(default=False, init=False)
-    ack: bool = field(default=False, init=False)
 
-    quit: t.Optional[QuitMessage] = field(default=None, init=False)
+    pending_new_time: NewTimeMessage | None = field(default=None, init=False)
     pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
-    processing_new_time: bool = False
+    pending_quit: QuitMessage | None = field(default=None, init=False)
 
     fsm_config: FSMConfig | None = None
     fsm: FSM[ConnectedModel, Message] = field(init=False)
@@ -187,7 +186,7 @@ class ConnectedModel:
 
     def log_invalid(self, message, valid_messages: t.Iterable[t.Type[Message]]):
         self.logger.error(
-            f"Received invalid message in {message} from model '{self.name}'. Expected one of "
+            f"Received invalid message {message} from model '{self.name}'. Expected one of "
             + ", ".join(m.__name__ for m in valid_messages)
         )
 
@@ -239,16 +238,16 @@ class WaitingForMessage(BaseModelState):
             self._handle_response(msg)
 
     def process_new_time(self, msg: NewTimeMessage):
-        pass
+        self.context.pending_new_time = msg
 
     def process_no_update(self, msg: NoUpdateMessage):
         pass
 
     def process_update(self, msg: UpdateMessage):
-        pass
+        self.context.pending_updates.append(msg)
 
     def process_quit(self, msg: QuitMessage):
-        pass
+        self.context.pending_quit = msg
 
     @singledispatchmethod
     def _handle_response(self, msg: Message) -> None:
@@ -263,7 +262,6 @@ class WaitingForMessage(BaseModelState):
     @_handle_response.register
     def _(self, msg: AcknowledgeMessage) -> None:
         """when a model sends an accepted message, don't do extra logic"""
-        self.context.ack = True
         if not self.context.pending_updates:
             self.notify_subscribers()
 
@@ -286,14 +284,14 @@ class WaitingForMessage(BaseModelState):
     def _(self, msg: ErrorMessage) -> None:
         """When a model reports an error, set it to failed"""
         self.context.failed = True
-        self.context.quit = None
+        self.context.pending_quit = None
         self.context.pending_updates = []
 
-    def handle_invalid_response(self, msg: Message, valid_messages: t.Iterable[t.Type[Message]]):
+    def handle_invalid_response(self, msg: Response, valid_messages: t.Iterable[t.Type[Response]]):
         self.context.failed = True
         self.context.log_invalid(msg, valid_messages)
-        if not self.context.quit:
-            self.context.quit = QuitMessage()
+        if not self.context.pending_quit:
+            self.context.pending_quit = QuitMessage()
             self.context.pending_updates = []
 
     def notify_subscribers(self, command: t.Optional[Command] = None):
@@ -307,17 +305,6 @@ class Idle(WaitingForMessage):
 
     valid_commands = (NewTimeMessage, NoUpdateMessage, UpdateMessage, QuitMessage)
     valid_responses = ()
-
-    def process_new_time(self, msg: NewTimeMessage):
-        self.context.ack = False
-        self.context.processing_new_time = True
-        self.context.send_command(msg)
-
-    def process_update(self, msg: UpdateMessage):
-        self.context.pending_updates.append(msg)
-
-    def process_quit(self, msg: QuitMessage):
-        self.context.quit = msg
 
 
 class Busy(WaitingForMessage):
@@ -333,12 +320,6 @@ class Busy(WaitingForMessage):
         self.context.busy = True
         self.context.timer.start()
 
-    def process_update(self, msg: UpdateMessage):
-        self.context.pending_updates.append(msg)
-
-    def process_quit(self, msg: QuitMessage):
-        self.context.quit = msg
-
 
 class Registration(Busy):
     """A RegistrationMessage is expected from the model"""
@@ -348,14 +329,17 @@ class Registration(Busy):
 
 
 class NewTime(Busy):
-    """A NewTime message has been sent to the model, and it needs to Acknowledge that"""
+    """A NewTime message will be sent to the model, and it needs to Acknowledge that"""
 
     valid_commands = (UpdateMessage, NoUpdateMessage, QuitMessage)
     valid_responses = (AcknowledgeMessage, ErrorMessage)
 
     def on_enter(self):
+        if not isinstance(self.context.pending_new_time, NewTimeMessage):
+            raise RuntimeError("can only enter NewTime when there is a pending NewTimeMessage")
+        self.context.send_command(self.context.pending_new_time)
+        self.context.pending_new_time = None
         super().on_enter()
-        self.context.processing_new_time = False
 
 
 class Updating(Busy):
@@ -372,9 +356,6 @@ class PendingMoreUpdates(Idle):
 
     valid_commands = (NoUpdateMessage, UpdateMessage, QuitMessage)
     valid_responses = ()
-
-    def process_update(self, msg: UpdateMessage):
-        self.context.pending_updates.append(msg)
 
 
 class ProcessPendingUpdates(BaseModelState):
@@ -409,12 +390,11 @@ class ProcessPendingQuit(BaseModelState):
     """
 
     def run(self):
-        if not isinstance(self.context.quit, QuitMessage):
+        if not isinstance(self.context.pending_quit, QuitMessage):
             raise RuntimeError(
                 "can only enter ProcessPendingQuit when there is a QuitMessage pending"
             )
-        self.context.ack = False
-        self.context.send_command(self.context.quit)
+        self.context.send_command(self.context.pending_quit)
 
 
 class Finalizing(Busy):
@@ -439,10 +419,6 @@ class ModelCollection(dict[bytes, ConnectedModel]):
     @property
     def busy(self):
         return any(model.busy for model in self.values())
-
-    @property
-    def waiting_for(self):
-        return [model for model in self.values() if model.busy]
 
     @property
     def next_time(self):
@@ -479,7 +455,7 @@ class ModelHasFailed(Condition[ConnectedModel]):
 
 class HasPendingQuitAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return bool(self.context.quit and not self.context.busy)
+        return bool(self.context.pending_quit and not self.context.busy)
 
 
 class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
@@ -487,9 +463,9 @@ class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
         return bool(self.context.pending_updates and not self.context.busy)
 
 
-class IsProcessingNewTime(Condition[ConnectedModel]):
+class HasPendingNewTimeAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return self.context.processing_new_time
+        return bool(self.context.pending_new_time)
 
 
 class IsIdle(Condition[ConnectedModel]):
@@ -518,7 +494,7 @@ MODEL_FSM_CONFIG = FSMConfig(
         Idle: [
             (HasPendingQuitAndIdle, ProcessPendingQuit),
             (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
-            (IsProcessingNewTime, NewTime),
+            (HasPendingNewTimeAndIdle, NewTime),
         ],
         ProcessPendingUpdates: [
             (ModelWaitingForDependencies, PendingMoreUpdates),

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -465,7 +465,7 @@ class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
 
 class HasPendingNewTimeAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return bool(self.context.pending_new_time)
+        return bool(self.context.pending_new_time and not self.context.busy)
 
 
 class IsIdle(Condition[ConnectedModel]):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -221,9 +221,9 @@ class WaitingForMessage(BaseModelState):
     def recv_message(self, msg: Message):
         # Here we make use of the fact that for a typing.Union object, __args__ contains the
         # classes inside the union
-        if isinstance(msg, Command.__args__):
+        if isinstance(msg, Command):
             self.process_command(msg)
-        elif isinstance(msg, Response.__args__):
+        elif isinstance(msg, Response):
             self.handle_response(msg)
         else:
             raise TypeError("Unknown Message")
@@ -320,7 +320,7 @@ class WaitingForMessage(BaseModelState):
             # does not accept an UpdateMessage or NoUpdateMessage, but the (default)
             # ``ConnectedModel.fsm_config`` ensures that this cannot happen. In case of a custom
             # ``fsm_config`` and this method raises ``InvalidCommand``, this is caught upstream by
-            # the orchestrator's ``Config``
+            # the orchestrator's ``Context``
             model.recv_event(command)
 
 
@@ -328,6 +328,14 @@ class Idle(WaitingForMessage):
     """Base class for if a model is awaiting further instructions"""
 
     valid_commands = (NewTimeMessage, NoUpdateMessage, UpdateMessage, QuitMessage)
+
+    # In an Idle state, we don't expect any messages from a model. It is supposed to wait for
+    # further instructions. The model's current Stream implementation blocks the zmq.Socket while
+    # idle, so there is no way that the model can actually send a message. However, future
+    # implementations may allow for a model to asynchronously send a message that is not a response
+    # to a command, most likely to send an ErrorMessage if it has crashed due to external
+    # circumstance. Until that time tough, there are no valid responses while idle, since there is
+    # nothing to repond to
     valid_responses = ()
 
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -20,7 +20,7 @@ from movici_simulation_core.messages import (
 )
 from movici_simulation_core.utils.data_mask import masks_overlap
 
-from .fsm import FSM, Always, State, TransitionsT
+from .fsm import FSM, Always, Condition, FSMConfig, State
 from .interconnectivity import Publisher, format_matrix
 from .stopwatch import ReportingStopwatch, Stopwatch
 
@@ -159,7 +159,9 @@ class ConnectedModel:
 
     quit: t.Optional[QuitMessage] = field(default=None, init=False)
     pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
+    processing_new_time: bool = False
 
+    fsm_config: FSMConfig | None = None
     fsm: FSM[ConnectedModel, Message] = field(init=False)
 
     def __post_init__(self):
@@ -171,7 +173,7 @@ class ConnectedModel:
                 f"Total time spent in in model '{self.name}': {s:.1f} seconds "
             ),
         )
-        self.fsm = FSM(Registration, self, raise_on_done=False)
+        self.fsm = FSM(self.fsm_config or MODEL_FSM_CONFIG, self, raise_on_done=False)
         self.fsm.start()
 
     def recv_event(self, event: Message):
@@ -193,15 +195,6 @@ class ConnectedModel:
 class BaseModelState(State[ConnectedModel], ABC):
     valid_commands: t.Tuple[t.Type[Command], ...] = ()
     valid_responses: t.Tuple[t.Type[Response], ...] = ()
-    next_state: t.Type[BaseModelState] = None
-
-    def transitions(self) -> TransitionsT:
-        if self.next_state is not None:
-            return [(Always, self.next_state)]
-        return self._transitions()
-
-    def _transitions(self):
-        return []
 
 
 class WaitingForMessage(BaseModelState):
@@ -300,7 +293,6 @@ class WaitingForMessage(BaseModelState):
         if not self.context.quit:
             self.context.quit = QuitMessage()
             self.context.pending_updates = []
-            self.next_state = ProcessPendingQuit
 
     def notify_subscribers(self, command: t.Optional[Command] = None):
         command = command or NoUpdateMessage()
@@ -316,16 +308,14 @@ class Idle(WaitingForMessage):
 
     def process_new_time(self, msg: NewTimeMessage):
         self.context.ack = False
+        self.context.processing_new_time = True
         self.context.send_command(msg)
-        self.next_state = NewTime
 
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
-        self.next_state = ProcessPendingUpdates
 
     def process_quit(self, msg: QuitMessage):
         self.context.quit = msg
-        self.next_state = ProcessPendingQuit
 
 
 class Busy(WaitingForMessage):
@@ -342,14 +332,6 @@ class Busy(WaitingForMessage):
 
     def process_quit(self, msg: QuitMessage):
         self.context.quit = msg
-
-    def _transitions(self):
-        return [
-            (lambda c: c.failed, Done),
-            (lambda c: (not c.busy) and c.quit, ProcessPendingQuit),
-            (lambda c: (not c.busy) and c.pending_updates, ProcessPendingUpdates),
-            (lambda c: not c.busy, Idle),
-        ]
 
 
 class Registration(Busy):
@@ -368,6 +350,9 @@ class NewTime(Busy):
 
     valid_commands = (UpdateMessage, NoUpdateMessage, QuitMessage)
     valid_responses = (AcknowledgeMessage, ErrorMessage)
+
+    def on_enter(self):
+        self.context.processing_new_time = False
 
 
 class Updating(Busy):
@@ -388,9 +373,6 @@ class PendingMoreUpdates(Idle):
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
 
-    def _transitions(self):
-        return [(Always, ProcessPendingUpdates)]
-
 
 class ProcessPendingUpdates(BaseModelState):
     """While the model was Busy, one or more updates came in which needs to be processed, this
@@ -406,11 +388,9 @@ class ProcessPendingUpdates(BaseModelState):
             )
 
         if any(model.busy for model in self.context.subscribed_to):
-            self.next_state = PendingMoreUpdates
             return
 
         self.process_pending_updates()
-        self.next_state = Updating
 
     def process_pending_updates(self):
         updates = self.context.pending_updates
@@ -432,7 +412,6 @@ class ProcessPendingQuit(BaseModelState):
             )
         self.context.ack = False
         self.context.send_command(self.context.quit)
-        self.next_state = Finalizing
 
 
 class Finalizing(Busy):
@@ -444,11 +423,6 @@ class Finalizing(Busy):
 
     def process_command(self, msg: Command):
         pass
-
-    def _transitions(self):
-        return [
-            (lambda c: not c.busy, Done),
-        ]
 
 
 class Done(BaseModelState):
@@ -493,3 +467,87 @@ class ModelCollection(dict[bytes, ConnectedModel]):
     def reset_model_timers(self):
         for model in self.values():
             model.timer.reset()
+
+
+class ModelHasFailed(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return self.context.failed
+
+
+class HasMisbehaved(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.failed and self.context.quit)
+
+
+class HasPendingQuit(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.quit)
+
+
+class HasPendingQuitAndIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return (not self.context.busy) and bool(self.context.quit)
+
+
+class HasPendingUpdates(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool(self.context.pending_updates)
+
+
+class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return bool((not self.context.busy) and self.context.pending_updates)
+
+
+class IsIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return not self.context.busy
+
+
+class IsProcessingNewTime(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return self.context.processing_new_time
+
+
+class ModelWaitingForDependencies(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return any(model.busy for model in self.context.subscribed_to)
+
+
+# after invalid: a model should always process quit
+# When a model is busy and it receives a quit, it should not process it yet and stay in its own
+MODEL_BUSY_TRANSITIONS = (
+    (HasMisbehaved, ProcessPendingQuit),
+    (HasPendingQuitAndIdle, ProcessPendingQuit),
+    (ModelHasFailed, Done),
+    (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
+    (IsIdle, Idle),
+)
+
+MODEL_FSM_CONFIG = FSMConfig(
+    initial_state=Registration,
+    states={
+        Registration: MODEL_BUSY_TRANSITIONS,
+        NewTime: MODEL_BUSY_TRANSITIONS,
+        Updating: MODEL_BUSY_TRANSITIONS,
+        Idle: [
+            (HasPendingQuit, ProcessPendingQuit),
+            (HasPendingUpdates, ProcessPendingUpdates),
+            (IsProcessingNewTime, NewTime),
+        ],
+        ProcessPendingUpdates: [
+            (ModelWaitingForDependencies, PendingMoreUpdates),
+            (Always, Updating),
+        ],
+        PendingMoreUpdates: [
+            (Always, ProcessPendingUpdates),
+        ],
+        ProcessPendingQuit: [
+            (Always, Finalizing),
+        ],
+        Finalizing: [
+            (IsIdle, Done),
+        ],
+        Done: [],
+    },
+)

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -174,6 +174,8 @@ class ConnectedModel:
             ),
         )
         self.fsm = FSM(self.fsm_config or MODEL_FSM_CONFIG, self, raise_on_done=False)
+
+    def start(self):
         self.fsm.start()
 
     def recv_event(self, event: Message):
@@ -182,12 +184,10 @@ class ConnectedModel:
     def send_command(self, message: Command) -> None:
         """Send a message and start the timer. Also, start waiting"""
         self.send(message)
-        self.timer.start()
-        self.busy = True
 
     def log_invalid(self, message, valid_messages: t.Iterable[t.Type[Message]]):
         self.logger.error(
-            f"Received invalid message {message} from model '{self.name}'. Expected one of "
+            f"Received invalid message in {message} from model '{self.name}'. Expected one of "
             + ", ".join(m.__name__ for m in valid_messages)
         )
 
@@ -214,8 +214,10 @@ class WaitingForMessage(BaseModelState):
 
     def process_command(self, msg: Command):
         if not isinstance(msg, self.valid_commands):
-            self.handle_invalid(msg, self.valid_commands)
-            return
+            raise ValueError(
+                f"Received invalid command {msg} for model '{self.context.name}'. Expected one of "
+                + ", ".join(m.__name__ for m in self.valid_commands)
+            )
 
         if isinstance(msg, NewTimeMessage):
             self.process_new_time(msg)
@@ -232,7 +234,7 @@ class WaitingForMessage(BaseModelState):
         self.context.busy = False
 
         if not isinstance(msg, self.valid_responses):
-            self.handle_invalid(msg, self.valid_responses)
+            self.handle_invalid_response(msg, self.valid_responses)
         else:
             self._handle_response(msg)
 
@@ -287,9 +289,9 @@ class WaitingForMessage(BaseModelState):
         self.context.quit = None
         self.context.pending_updates = []
 
-    def handle_invalid(self, msg: Message, valid_messages: t.Iterable[t.Type[Message]]):
-        self.context.log_invalid(msg, valid_messages)
+    def handle_invalid_response(self, msg: Message, valid_messages: t.Iterable[t.Type[Message]]):
         self.context.failed = True
+        self.context.log_invalid(msg, valid_messages)
         if not self.context.quit:
             self.context.quit = QuitMessage()
             self.context.pending_updates = []
@@ -327,6 +329,10 @@ class Busy(WaitingForMessage):
     valid_commands = (UpdateMessage, NoUpdateMessage, QuitMessage)
     valid_responses = (ErrorMessage,)
 
+    def on_enter(self):
+        self.context.busy = True
+        self.context.timer.start()
+
     def process_update(self, msg: UpdateMessage):
         self.context.pending_updates.append(msg)
 
@@ -340,10 +346,6 @@ class Registration(Busy):
     valid_commands = (QuitMessage,)
     valid_responses = (RegistrationMessage, ErrorMessage)
 
-    def on_enter(self):
-        self.context.busy = True
-        self.context.timer.start()
-
 
 class NewTime(Busy):
     """A NewTime message has been sent to the model, and it needs to Acknowledge that"""
@@ -352,6 +354,7 @@ class NewTime(Busy):
     valid_responses = (AcknowledgeMessage, ErrorMessage)
 
     def on_enter(self):
+        super().on_enter()
         self.context.processing_new_time = False
 
 
@@ -474,34 +477,14 @@ class ModelHasFailed(Condition[ConnectedModel]):
         return self.context.failed
 
 
-class HasMisbehaved(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.failed and self.context.quit)
-
-
-class HasPendingQuit(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.quit)
-
-
 class HasPendingQuitAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return (not self.context.busy) and bool(self.context.quit)
-
-
-class HasPendingUpdates(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return bool(self.context.pending_updates)
+        return bool(self.context.quit and not self.context.busy)
 
 
 class HasPendingUpdatesAndIdle(Condition[ConnectedModel]):
     def met(self) -> bool:
-        return bool((not self.context.busy) and self.context.pending_updates)
-
-
-class IsIdle(Condition[ConnectedModel]):
-    def met(self) -> bool:
-        return not self.context.busy
+        return bool(self.context.pending_updates and not self.context.busy)
 
 
 class IsProcessingNewTime(Condition[ConnectedModel]):
@@ -509,15 +492,17 @@ class IsProcessingNewTime(Condition[ConnectedModel]):
         return self.context.processing_new_time
 
 
+class IsIdle(Condition[ConnectedModel]):
+    def met(self) -> bool:
+        return not self.context.busy
+
+
 class ModelWaitingForDependencies(Condition[ConnectedModel]):
     def met(self) -> bool:
         return any(model.busy for model in self.context.subscribed_to)
 
 
-# after invalid: a model should always process quit
-# When a model is busy and it receives a quit, it should not process it yet and stay in its own
 MODEL_BUSY_TRANSITIONS = (
-    (HasMisbehaved, ProcessPendingQuit),
     (HasPendingQuitAndIdle, ProcessPendingQuit),
     (ModelHasFailed, Done),
     (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
@@ -531,8 +516,8 @@ MODEL_FSM_CONFIG = FSMConfig(
         NewTime: MODEL_BUSY_TRANSITIONS,
         Updating: MODEL_BUSY_TRANSITIONS,
         Idle: [
-            (HasPendingQuit, ProcessPendingQuit),
-            (HasPendingUpdates, ProcessPendingUpdates),
+            (HasPendingQuitAndIdle, ProcessPendingQuit),
+            (HasPendingUpdatesAndIdle, ProcessPendingUpdates),
             (IsProcessingNewTime, NewTime),
         ],
         ProcessPendingUpdates: [

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -125,10 +125,10 @@ class TimelineController:
     def set_model_to_start(self, model: ConnectedModel):
         model.next_time = self.start
 
-    def set_next_time(self, model: ConnectedModel, next_time: t.Optional[int] = None):
+    def set_next_time(self, model: ConnectedModel, next_time: int | None = None):
         model.next_time = self._get_validated_next_time(next_time)
 
-    def _get_validated_next_time(self, next_time: t.Optional[int]):
+    def _get_validated_next_time(self, next_time: int | None):
         current_time = self.current_time if self.current_time is not None else self.start
         if (
             next_time is None
@@ -149,8 +149,8 @@ class NoUpdateMessage(Message):
     pass
 
 
-Command = t.Union[NewTimeMessage, UpdateMessage, NoUpdateMessage, UpdateSeriesMessage, QuitMessage]
-Response = t.Union[RegistrationMessage, AcknowledgeMessage, ResultMessage, ErrorMessage]
+Command = NewTimeMessage | UpdateMessage | NoUpdateMessage | UpdateSeriesMessage | QuitMessage
+Response = RegistrationMessage | AcknowledgeMessage | ResultMessage | ErrorMessage
 
 
 @dataclass
@@ -169,14 +169,14 @@ class ConnectedModel:
     sub: dict | None = field(default_factory=dict)
 
     busy: bool = field(default=False, init=False)
-    next_time: t.Optional[int] = field(default=None, init=False)
+    next_time: int | None = field(default=None, init=False)
     failed: bool = field(default=False, init=False)
 
     pending_new_time: NewTimeMessage | None = field(default=None, init=False)
-    pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
+    pending_updates: list[UpdateMessage] = field(default_factory=list, init=False)
     pending_quit: QuitMessage | None = field(default=None, init=False)
 
-    fsm_config: FSMConfig | None = None
+    fsm_config: FSMConfig[ConnectedModel] | None = None
     fsm: FSM[ConnectedModel, Message] = field(init=False)
 
     def __post_init__(self):
@@ -197,10 +197,10 @@ class ConnectedModel:
         self.fsm.handle_event(event)
 
     def send_command(self, message: Command) -> None:
-        """Send a message and start the timer. Also, start waiting"""
+        """Send a command message to the model"""
         self.send(message)
 
-    def log_invalid(self, message, valid_messages: t.Iterable[t.Type[Message]]):
+    def log_invalid(self, message, valid_messages: t.Iterable[type[Message]]):
         self.logger.error(
             f"Received invalid message {message} from model '{self.name}'. Expected one of "
             + ", ".join(m.__name__ for m in valid_messages)
@@ -208,8 +208,8 @@ class ConnectedModel:
 
 
 class BaseModelState(State[ConnectedModel], ABC):
-    valid_commands: t.Tuple[t.Type[Command], ...] = ()
-    valid_responses: t.Tuple[t.Type[Response], ...] = ()
+    valid_commands: tuple[type[Command], ...] = ()
+    valid_responses: tuple[type[Response], ...] = ()
 
 
 class WaitingForMessage(BaseModelState):
@@ -304,14 +304,14 @@ class WaitingForMessage(BaseModelState):
         self.context.pending_quit = None
         self.context.pending_updates = []
 
-    def handle_invalid_response(self, msg: Response, valid_messages: t.Iterable[t.Type[Response]]):
+    def handle_invalid_response(self, msg: Response, valid_messages: t.Iterable[type[Response]]):
         self.context.failed = True
         self.context.log_invalid(msg, valid_messages)
         if not self.context.pending_quit:
             self.context.pending_quit = QuitMessage()
             self.context.pending_updates = []
 
-    def notify_subscribers(self, command: t.Optional[Command] = None):
+    def notify_subscribers(self, command: Command | None = None):
         command = command or NoUpdateMessage()
         for model in self.context.publishes_to:
             model.recv_event(command)

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -45,7 +45,9 @@ class Context:
 
     @property
     def failed(self):
-        return self.orchestrator_failed or self.models.failed
+        if self.orchestrator_failed:
+            return ["orchestrator", *self.models.failed]
+        return self.models.failed
 
     def log_new_phase(self, phase: str):
         self.logger.info(f"Entering {phase}")
@@ -105,11 +107,11 @@ class Context:
             self.logger.info("Simulation successfully finished")
         elif len(self.failed) == 1:
             self.logger.error(
-                f"Simulation unexpectedly ended due to a failure of model '{self.failed[0]}'"
+                f"Simulation unexpectedly ended due to a failure of component '{self.failed[0]}'"
             )
         else:
             self.logger.error(
-                "Simulation unexpectedly ended due to a failure of models "
+                "Simulation unexpectedly ended due to a failure of components "
                 + ", ".join(f"'{model}'" for model in self.failed)
             )
 
@@ -192,7 +194,7 @@ class ConnectedModel:
         self.fsm.start()
 
     def recv_event(self, event: Message):
-        self.fsm.send(event)
+        self.fsm.handle_event(event)
 
     def send_command(self, message: Command) -> None:
         """Send a message and start the timer. Also, start waiting"""
@@ -211,9 +213,10 @@ class BaseModelState(State[ConnectedModel], ABC):
 
 
 class WaitingForMessage(BaseModelState):
-    def run(self):
-        msg = yield
-        self.recv_message(msg)
+    requires_event = True
+
+    def handle_event(self, event: Message):
+        self.recv_message(event)
 
     def recv_message(self, msg: Message):
         # Here we make use of the fact that for a typing.Union object, __args__ contains the
@@ -425,8 +428,10 @@ class Finalizing(Busy):
 class Done(BaseModelState):
     """The model is either done or failed, ignore any further messages"""
 
-    def run(self):
-        yield
+    requires_event = True
+
+    def handle_event(self, event):
+        return
 
 
 class ModelCollection(dict[bytes, ConnectedModel]):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/context.py
@@ -21,7 +21,7 @@ from movici_simulation_core.messages import (
 from movici_simulation_core.utils.data_mask import masks_overlap
 
 from .fsm import FSM, Always, State, TransitionsT
-from .interconnectivity import format_matrix
+from .interconnectivity import Publisher, format_matrix
 from .stopwatch import ReportingStopwatch, Stopwatch
 
 
@@ -48,6 +48,22 @@ class Context:
     def log_new_phase(self, phase: str):
         self.logger.info(f"Entering {phase}")
 
+    def queue_models_for_next_time(self):
+        next_time = self.models.next_time
+        if next_time is None:
+            raise RuntimeError(
+                "Cannot progress to next time when all models are done,"
+                " should finalize simulation instead"
+            )
+
+        if next_time != self.timeline.current_time:
+            self.timeline.current_time = next_time
+            self.models.queue_all(NewTimeMessage(next_time))
+
+        for model in self.models.values():
+            if model.next_time == next_time:
+                model.recv_event(UpdateMessage(timestamp=next_time))
+
     def log_new_time(self):
         if self.models.next_time != self.timeline.current_time:
             self.logger.info(f"New time: {self.models.next_time}")
@@ -59,7 +75,10 @@ class Context:
         self.logger.info(f"Total elapsed time: {seconds:.1f}")
 
     def log_interconnectivity_matrix(self):
-        self.logger.info("Model interconnectivity matrix:\n" + format_matrix(self.models.values()))
+        self.logger.info(
+            "Model interconnectivity matrix:\n"
+            + format_matrix(t.cast(list[Publisher], list(self.models.values())))
+        )
 
     def finalize(self):
         self.phase_timer.reset()
@@ -85,7 +104,7 @@ class Context:
 class TimelineController:
     start: int
     end: int
-    current_time: int = None
+    current_time: int | None = None
 
     def set_model_to_start(self, model: ConnectedModel):
         model.next_time = self.start
@@ -103,13 +122,6 @@ class TimelineController:
             return None
 
         return min(next_time, self.end)
-
-    def queue_for_next_time(self, models: ModelCollection):
-        next_time = models.next_time
-        if next_time != self.current_time:
-            self.current_time = next_time
-            models.queue_all(NewTimeMessage(next_time))
-        models.queue_models_for_next_time()
 
 
 class NoUpdateMessage(Message):
@@ -134,11 +146,11 @@ class ConnectedModel:
     send: t.Callable[[Message], None]
 
     logger: logging.Logger = field(default_factory=logging.getLogger)
-    publishes_to: t.Optional[t.List[ConnectedModel]] = field(default_factory=list)
-    subscribed_to: t.Optional[t.List[ConnectedModel]] = field(default_factory=list)
-    timer: Stopwatch = field(default=None)
-    pub: t.Optional[dict] = field(default_factory=dict)
-    sub: t.Optional[dict] = field(default_factory=dict)
+    publishes_to: list[ConnectedModel] = field(default_factory=list)
+    subscribed_to: list[ConnectedModel] = field(default_factory=list)
+    timer: Stopwatch = field(init=False)
+    pub: dict | None = field(default_factory=dict)
+    sub: dict | None = field(default_factory=dict)
 
     busy: bool = field(default=False, init=False)
     next_time: t.Optional[int] = field(default=None, init=False)
@@ -148,10 +160,10 @@ class ConnectedModel:
     quit: t.Optional[QuitMessage] = field(default=None, init=False)
     pending_updates: t.List[UpdateMessage] = field(default_factory=list, init=False)
 
-    fsm: FSM[ConnectedModel] = field(init=False)
+    fsm: FSM[ConnectedModel, Message] = field(init=False)
 
     def __post_init__(self):
-        self.timer = self.timer or ReportingStopwatch(
+        self.timer = ReportingStopwatch(
             on_stop=lambda s: self.logger.debug(
                 f"Model '{self.name}' returned in {s:.1f} seconds "
             ),
@@ -418,12 +430,9 @@ class ProcessPendingQuit(BaseModelState):
             raise RuntimeError(
                 "can only enter ProcessPendingQuit when there is a QuitMessage pending"
             )
-        self.process_pending_quit()
-        self.next_state = Finalizing
-
-    def process_pending_quit(self):
         self.context.ack = False
         self.context.send_command(self.context.quit)
+        self.next_state = Finalizing
 
 
 class Finalizing(Busy):
@@ -449,7 +458,7 @@ class Done(BaseModelState):
         yield
 
 
-class ModelCollection(dict, t.Dict[bytes, ConnectedModel]):
+class ModelCollection(dict[bytes, ConnectedModel]):
     @property
     def busy(self):
         return any(model.busy for model in self.values())
@@ -473,13 +482,6 @@ class ModelCollection(dict, t.Dict[bytes, ConnectedModel]):
         """add a message to the queue of all models"""
         for model in self.values():
             model.recv_event(message)
-
-    def queue_models_for_next_time(self):
-        """Queue an update message to the model(s) that have the specified next_time"""
-        next_time = self.next_time
-        for model in self.values():
-            if model.next_time == next_time:
-                model.recv_event(UpdateMessage(timestamp=next_time))
 
     def determine_interdependency(self):
         """calculate the subscribers for every model based on the pub/sub mask."""

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -44,7 +44,7 @@ class FSMConfig(t.Generic[T]):
     :param initial_state: the initial state
     :param states: a dictionary of all possible states as ``type``s and their transitions.
         Transitions are a sequence of ``(type[Condition], type[State])`` tuples
-    :pararm strict: a boolean whether to validate that all states mentioned in the transitions
+    :param strict: a boolean whether to validate that all states mentioned in the transitions
         and ``initial`` state must have an entry in the states  dictionary
     """
 
@@ -69,12 +69,7 @@ class FSMConfig(t.Generic[T]):
 
 
 class FSM(t.Generic[T, E]):
-    def __init__(
-        self,
-        config: FSMConfig[T],
-        context: T = None,
-        raise_on_done=True,
-    ):
+    def __init__(self, config: FSMConfig[T], context: T = None, raise_on_done=True):
         self.context = context
         self.config = config
         self.state = config.initial_state(context=self.context)

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
+import contextlib
 import dataclasses
-import functools
-import inspect
 import itertools
 import typing as t
 from abc import ABC, abstractmethod
@@ -11,30 +10,6 @@ from movici_simulation_core.exceptions import FSMDone, FSMError, FSMException, F
 
 T = t.TypeVar("T")
 E = t.TypeVar("E")
-
-
-def send_silent(coro: t.Generator, value: t.Any):
-    try:
-        coro.send(value)
-    except StopIteration:
-        pass
-
-
-def fsm_conditional_raise(attribute: str, exc: t.Type[Exception]):
-    def _decorator(func):
-        @functools.wraps(func)
-        def wrapper(fsm: FSM, *args, **kwargs):
-            if getattr(fsm, attribute):
-                raise exc()
-            return func(fsm, *args, **kwargs)
-
-        return wrapper
-
-    return _decorator
-
-
-not_started = fsm_conditional_raise(attribute="started", exc=FSMStarted)
-not_done = fsm_conditional_raise(attribute="done", exc=FSMDone)
 
 
 @dataclasses.dataclass
@@ -69,7 +44,10 @@ class FSMConfig(t.Generic[T]):
 
 
 class FSM(t.Generic[T, E]):
+    state: State[T]
+
     def __init__(self, config: FSMConfig[T], context: T = None, raise_on_done=True):
+
         self.context = context
         self.config = config
         self.state = config.initial_state(context=self.context)
@@ -79,22 +57,32 @@ class FSM(t.Generic[T, E]):
         self.failure = False
         self.raise_on_done = raise_on_done
 
-    @not_done
-    @not_started
     def start(self):
+        self.ensure_not_done()
+        self.ensure_not_started()
         self.started = True
-        self.runner = self._run()
-        send_silent(self.runner, None)
-
-    def _run(self):
-        try:
+        with self.catch_fsmexceptions():
             self.state.on_enter()
-            while True:
-                if inspect.isgeneratorfunction(self.state.run):
-                    yield from self.state.run()
-                else:
-                    self.state.run()
-                self.transition()
+            self.run_until_event_required()
+
+    def handle_event(self, event: E):
+        self.ensure_not_done()
+        assert self.state.requires_event
+
+        with self.catch_fsmexceptions():
+            self.state.handle_event(event)
+            self.state = self.transition()
+            self.run_until_event_required()
+
+    def run_until_event_required(self):
+        while not self.state.requires_event:
+            self.state.run()
+            self.state = self.transition()
+
+    @contextlib.contextmanager
+    def catch_fsmexceptions(self):
+        try:
+            yield
         except FSMException as e:
             self.done = True
             if isinstance(e, FSMError):
@@ -103,15 +91,19 @@ class FSM(t.Generic[T, E]):
             if self.raise_on_done:
                 raise
 
-    @not_done
-    def send(self, event: E):
-        assert self.runner is not None
-        send_silent(self.runner, event)
-
     def transition(self):
         if new_state := next_state(self.context, self.config.states.get(type(self.state), [])):
             self.state = new_state(self.context)
             self.state.on_enter()
+        return self.state
+
+    def ensure_not_started(self):
+        if self.started:
+            raise FSMStarted()
+
+    def ensure_not_done(self):
+        if self.done:
+            raise FSMDone()
 
 
 def next_state(context, transitions: TransitionsT):
@@ -121,23 +113,20 @@ def next_state(context, transitions: TransitionsT):
     return None
 
 
-class Event:
-    pass
-
-
 class State(ABC, t.Generic[T]):
+    requires_event = False
+
     def __init__(self, context: T):
         self.context = context
 
-    def on_enter(self):
-        pass
-
-    @abstractmethod
     def run(self):
         raise NotImplementedError
 
-    def transitions(self) -> TransitionsT:
-        return []
+    def handle_event(self, event: t.Any):
+        raise NotImplementedError
+
+    def on_enter(self):
+        pass
 
 
 class Condition(ABC, t.Generic[T]):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -18,17 +18,17 @@ def send_silent(coro: t.Generator, value: t.Any):
         pass
 
 
-def fsm_conditional_raise(func=None, attribute: str = None, exc: t.Type[Exception] = None):
-    if func is None:
-        return functools.partial(fsm_conditional_raise, attribute=attribute, exc=exc)
+def fsm_conditional_raise(attribute: str, exc: t.Type[Exception]):
+    def _decorator(func):
+        @functools.wraps(func)
+        def wrapper(fsm: FSM, *args, **kwargs):
+            if getattr(fsm, attribute):
+                raise exc()
+            return func(fsm, *args, **kwargs)
 
-    @functools.wraps(func)
-    def wrapper(fsm: FSM, *args, **kwargs):
-        if getattr(fsm, attribute):
-            raise exc()
-        return func(fsm, *args, **kwargs)
+        return wrapper
 
-    return wrapper
+    return _decorator
 
 
 not_started = fsm_conditional_raise(attribute="started", exc=FSMStarted)
@@ -70,6 +70,7 @@ class FSM(t.Generic[T, E]):
 
     @not_done
     def send(self, event: E):
+        assert self.runner is not None
         send_silent(self.runner, event)
 
     def transition(self):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -110,7 +110,6 @@ class FSM(t.Generic[T, E]):
             self.run_until_event_required()
 
     def handle_event(self, event: E):
-        """When an"""
         self.ensure_not_done()
         assert self.state.requires_event
 
@@ -185,7 +184,7 @@ class State(ABC, t.Generic[T]):
 
     def handle_event(self, event: t.Any):
         """Entry point for a state that requires an event. This method will be called by the FSM
-        when the class variable ``requires_event`` is set to ``True `` and it receives an event
+        when the class variable ``requires_event`` is set to ``True`` and it receives an event
         from upstream
         """
         raise NotImplementedError(

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -18,7 +18,10 @@ class FSMConfig(t.Generic[T]):
 
     :param initial_state: the initial state
     :param states: a dictionary of all possible states as ``type``s and their transitions.
-        Transitions are a sequence of ``(type[Condition], type[State])`` tuples
+        Transitions are a sequence of ``(type[Condition], type[State])`` tuples. When determining
+        which State to transition to, the transitions are checked starting from the top entry in
+        the transitions sequence. The FSM transitions to the state belonging to the first
+        transition that is matched.
     :param strict: a boolean whether to validate that all states mentioned in the transitions
         and ``initial`` state must have an entry in the states  dictionary
     """
@@ -35,6 +38,19 @@ class FSMConfig(t.Generic[T]):
                 f"'initial_state' {self.initial_state.__name__} is not a member of 'states' "
                 "and 'strict' was set"
             )
+
+        for state in self.states.keys():
+            if not state.requires_event and state.run is State.run:
+                raise ValueError(
+                    f"State {state.__name__} has 'requires_event' unset but did not implement a"
+                    " 'run' method"
+                )
+            if state.requires_event and state.handle_event is State.handle_event:
+                raise ValueError(
+                    f"State {state.__name__} has 'requires_event' set but did not implement a"
+                    " 'handle_event' method"
+                )
+
         for _, state in itertools.chain.from_iterable(self.states.values()):
             if state not in self.states:
                 raise ValueError(
@@ -44,12 +60,40 @@ class FSMConfig(t.Generic[T]):
 
 
 class FSM(t.Generic[T, E]):
+    """Implementation of a Finite State Machine runner. Requires a ``FSMConfig`` as a definition
+    of the available states and the possible transitions. The config contains an ``initial_state``
+    that is entered when the ``FSM`` is started by invoking the :meth:`FSM.start` method. If the
+    initial state is configured with ``requires_event=True``, then the ``FSM`` waits until the
+    :meth:`FSM.handle_event` method is called upon which it will pass the event through to the
+    active state by calling the state's ``handle_event`` method, which the State must have
+    implemented if it has ``requires_event`` set to ``True``. If the active state does not have
+    ``requires_event=True`` it will call the ``run`` method instead. After every state is invoked
+    (by calling either the ``handle_event`` or ``run`` method) the configured transitions for the
+    state (as given by the ``FSMConfig``) are evaluated against the context. The FSM transitions
+    to State belonging to the first matched transition, which will become the active state. If no
+    condition is matched, then the current state remains the active state for the next iteration.
+    The FSM continues to call the active state's ``run`` method and transition until it encounters
+    a state that has ``requires_event=True`` upon which it will wait for :meth:`FSM.handle_event`
+    to be called.
+
+    The FSM may terminate iff a state raises an ``FSMException``, usually ``FSMDone`` to indicate
+    a normal end to the FSM, or ``FSMError`` in case of an abnormal end to the ``FSM``. If an
+    ``FSMError`` was raised then the :attr:`FSM.failure` flag will be set. If no valid state ever
+    raises an ``FSMException`` then the ``FSM`` may run indefinitely
+
+    :param config: An ``FSMConfig`` for the finite state machine.
+    :param context: An arbitrary, mutalbe object that is kept for the lifetime of the FSM. It can
+        be used to store state that must be shared between States and will be used to evaluate any
+        transition conditions
+    :param raise_on_done: A boolean to indicate whether to raise an ``FSMException`` in case the
+        FSM terminates. The exception will be the same as the exception that terminated the ``FSM``
+    """
+
     state: State[T]
 
     def __init__(self, config: FSMConfig[T], context: T = None, raise_on_done=True):
-
-        self.context = context
         self.config = config
+        self.context = context
         self.state = config.initial_state(context=self.context)
         self.started = False
         self.done = False
@@ -57,6 +101,7 @@ class FSM(t.Generic[T, E]):
         self.raise_on_done = raise_on_done
 
     def start(self):
+        """Start the FSM"""
         self.ensure_not_done()
         self.ensure_not_started()
         self.started = True
@@ -65,6 +110,7 @@ class FSM(t.Generic[T, E]):
             self.run_until_event_required()
 
     def handle_event(self, event: E):
+        """When an"""
         self.ensure_not_done()
         assert self.state.requires_event
 
@@ -113,18 +159,43 @@ def next_state(context, transitions: TransitionsT):
 
 
 class State(ABC, t.Generic[T]):
+    """Base class for FSM States. When subclassing a State, implement one of the ``run`` or
+    ``handle_event`` methods. If a state is a transient state and needs to run its logic and
+    transition to a new state immediately, implement the ``run`` method. If a state needs to wait
+    for an event to be sent, set the ``State.requires_event`` class variable to ``True`` and
+    implement the ``handle_event`` method
+    """
+
     requires_event = False
 
     def __init__(self, context: T):
         self.context = context
 
     def run(self):
-        raise NotImplementedError
+        """Entry point for a state that does not require an event. This method will be called
+        unconditionally by the ``FSM`` when ``requires_event`` is set to ``False`` (the default).
+        States that do no have ``requires_event`` set are generally transient states that need to
+        run some logic before immediately transitioning to another state
+        """
+        raise NotImplementedError(
+            f"'run' was called on an instance of {type(self).__name__} while it did not implement"
+            f" the method. Either implement 'run', or set '{type(self).__name__}.requires_event'"
+            " and implement 'handle_event'"
+        )
 
     def handle_event(self, event: t.Any):
-        raise NotImplementedError
+        """Entry point for a state that requires an event. This method will be called by the FSM
+        when the class variable ``requires_event`` is set to ``True `` and it receives an event
+        from upstream
+        """
+        raise NotImplementedError(
+            f"'handle_event' was called on an instance of {type(self).__name__} while it did not"
+            f" implement the method. Either implement 'handle_event', or set"
+            f" '{type(self).__name__}.requires_event' and implement 'run'"
+        )
 
     def on_enter(self):
+        """Called once by the ``FSM`` when entering a state"""
         pass
 
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -93,6 +93,7 @@ class FSM(t.Generic[T, E]):
 
     def _run(self):
         try:
+            self.state.on_enter()
             while True:
                 if inspect.isgeneratorfunction(self.state.run):
                     yield from self.state.run()
@@ -115,6 +116,7 @@ class FSM(t.Generic[T, E]):
     def transition(self):
         if new_state := next_state(self.context, self.config.states.get(type(self.state), [])):
             self.state = new_state(self.context)
+            self.state.on_enter()
 
 
 def next_state(context, transitions: TransitionsT):
@@ -131,7 +133,6 @@ class Event:
 class State(ABC, t.Generic[T]):
     def __init__(self, context: T):
         self.context = context
-        self.on_enter()
 
     def on_enter(self):
         pass

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -51,7 +51,6 @@ class FSM(t.Generic[T, E]):
         self.context = context
         self.config = config
         self.state = config.initial_state(context=self.context)
-        self.runner = None
         self.started = False
         self.done = False
         self.failure = False

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -38,7 +38,7 @@ class FSMConfig(t.Generic[T]):
         for _, state in itertools.chain.from_iterable(self.states.values()):
             if state not in self.states:
                 raise ValueError(
-                    f"State {state.__name__} was mentioned in a transition but it is not a member"
+                    f"State {state.__name__} was mentioned in a transition but it is not a member "
                     "of 'states' and 'strict' was set"
                 )
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/fsm.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import dataclasses
 import functools
 import inspect
+import itertools
 import typing as t
 from abc import ABC, abstractmethod
 
@@ -35,10 +37,47 @@ not_started = fsm_conditional_raise(attribute="started", exc=FSMStarted)
 not_done = fsm_conditional_raise(attribute="done", exc=FSMDone)
 
 
+@dataclasses.dataclass
+class FSMConfig(t.Generic[T]):
+    """A config for setting up a :class:`FSM` final state machine
+
+    :param initial_state: the initial state
+    :param states: a dictionary of all possible states as ``type``s and their transitions.
+        Transitions are a sequence of ``(type[Condition], type[State])`` tuples
+    :pararm strict: a boolean whether to validate that all states mentioned in the transitions
+        and ``initial`` state must have an entry in the states  dictionary
+    """
+
+    initial_state: type[State[T]]
+    states: dict[type[State[T]], TransitionsT] = dataclasses.field(default_factory=dict)
+    strict: bool = True
+
+    def __post_init__(self):
+        if not self.strict:
+            return
+        if self.initial_state not in self.states:
+            raise ValueError(
+                f"'initial_state' {self.initial_state.__name__} is not a member of 'states' "
+                "and 'strict' was set"
+            )
+        for _, state in itertools.chain.from_iterable(self.states.values()):
+            if state not in self.states:
+                raise ValueError(
+                    f"State {state.__name__} was mentioned in a transition but it is not a member"
+                    "of 'states' and 'strict' was set"
+                )
+
+
 class FSM(t.Generic[T, E]):
-    def __init__(self, initial_state: t.Type[State], context: T = None, raise_on_done=True):
+    def __init__(
+        self,
+        config: FSMConfig[T],
+        context: T = None,
+        raise_on_done=True,
+    ):
         self.context = context
-        self.state = initial_state(context=self.context)
+        self.config = config
+        self.state = config.initial_state(context=self.context)
         self.runner = None
         self.started = False
         self.done = False
@@ -74,13 +113,13 @@ class FSM(t.Generic[T, E]):
         send_silent(self.runner, event)
 
     def transition(self):
-        if new_state := next_state(self.state):
+        if new_state := next_state(self.context, self.config.states.get(type(self.state), [])):
             self.state = new_state(self.context)
 
 
-def next_state(state: State) -> t.Optional[t.Type[State]]:
-    for cond, new_state in state.transitions():
-        if cond(state.context):
+def next_state(context, transitions: TransitionsT):
+    for cond, new_state in transitions:
+        if cond(context):
             return new_state
     return None
 
@@ -122,4 +161,4 @@ class Always(Condition):
         return True
 
 
-TransitionsT = t.List[t.Tuple[t.Type[Condition], t.Type[State]]]
+TransitionsT = t.Sequence[tuple[type[Condition], type[State]]]

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/interconnectivity.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/interconnectivity.py
@@ -3,14 +3,12 @@ from __future__ import annotations
 import typing as t
 
 
-class IPubSubFilter(t.Protocol):
+class Publisher(t.Protocol):
     name: str
-    pub: dict
-    sub: dict
-    subscribers: t.List[IPubSubFilter]
+    publishes_to: t.List[Publisher]
 
 
-def format_matrix(models: t.Sequence[IPubSubFilter], title="", match="X"):
+def format_matrix(models: t.Sequence[Publisher], title="", match="X"):
     """
     ::
 
@@ -28,7 +26,7 @@ def format_matrix(models: t.Sequence[IPubSubFilter], title="", match="X"):
     def header_row():
         return first_column(title) + "".join(box(num) for num in model_nums.values())
 
-    def model_row(model):
+    def model_row(model: Publisher):
         return first_column(box(model_nums[model.name]) + model.name) + "".join(
             box(match if sub in model.publishes_to else "") for sub in models
         )

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -96,12 +96,14 @@ class Orchestrator(Service):
         self.stream.set_handler(self.fsm.send)
 
     def _get_connected_model(self, identifier: str):
-        return ConnectedModel(
+        model = ConnectedModel(
             name=identifier,
             timeline=self.timeline,
             send=self.make_send(identifier),
             logger=self.logger,
         )
+        model.start()
+        return model
 
     def make_send(self, identifier: str):
         """create a send function that a can be used to send a message to a specific client

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -8,7 +8,7 @@ from movici_simulation_core.services.orchestrator.context import ConnectedModel,
 from movici_simulation_core.settings import Settings
 from movici_simulation_core.simulation import Simulation
 
-from .context import Context, TimelineController
+from .context import MODEL_FSM_CONFIG, Context, TimelineController
 from .fsm import FSM, Always, FSMConfig, FSMDone
 from .states import (
     AllModelsDone,
@@ -101,6 +101,7 @@ class Orchestrator(Service):
             timeline=self.timeline,
             send=self.make_send(identifier),
             logger=self.logger,
+            fsm_config=MODEL_FSM_CONFIG,
         )
         model.start()
         return model

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -93,7 +93,7 @@ class Orchestrator(Service):
 
     def _setup_fsm(self):
         self.fsm = FSM(FSM_CONFIG, context=self.context)
-        self.stream.set_handler(self.fsm.send)
+        self.stream.set_handler(self.fsm.handle_event)
 
     def _get_connected_model(self, identifier: str):
         model = ConnectedModel(

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/service.py
@@ -9,8 +9,52 @@ from movici_simulation_core.settings import Settings
 from movici_simulation_core.simulation import Simulation
 
 from .context import Context, TimelineController
-from .fsm import FSM, FSMDone
-from .states import StartInitializingPhase
+from .fsm import FSM, Always, FSMConfig, FSMDone
+from .states import (
+    AllModelsDone,
+    AllModelsReady,
+    EndFinalizingPhase,
+    Failed,
+    FinalizingWaitForModels,
+    ModelsRegistration,
+    NewTime,
+    StartFinalizingPhase,
+    StartInitializingPhase,
+    StartRunningPhase,
+    WaitForResults,
+)
+
+FSM_CONFIG = FSMConfig(
+    initial_state=StartInitializingPhase,
+    states={
+        StartInitializingPhase: [
+            (Always, ModelsRegistration),
+        ],
+        ModelsRegistration: [
+            (Failed, StartFinalizingPhase),
+            (AllModelsReady, StartRunningPhase),
+        ],
+        StartRunningPhase: [
+            (Always, NewTime),
+        ],
+        NewTime: [
+            (Always, WaitForResults),
+        ],
+        WaitForResults: [
+            (Failed, StartFinalizingPhase),
+            (AllModelsDone, StartFinalizingPhase),
+            (AllModelsReady, NewTime),
+        ],
+        StartFinalizingPhase: [
+            (AllModelsReady, EndFinalizingPhase),
+            (Always, FinalizingWaitForModels),
+        ],
+        FinalizingWaitForModels: [
+            (AllModelsReady, EndFinalizingPhase),
+        ],
+        EndFinalizingPhase: [],
+    },
+)
 
 
 class Orchestrator(Service):
@@ -48,7 +92,7 @@ class Orchestrator(Service):
         )
 
     def _setup_fsm(self):
-        self.fsm = FSM(StartInitializingPhase, context=self.context)
+        self.fsm = FSM(FSM_CONFIG, context=self.context)
         self.stream.set_handler(self.fsm.send)
 
     def _get_connected_model(self, identifier: str):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -6,12 +6,10 @@ from abc import ABC
 from movici_simulation_core.messages import QuitMessage
 from movici_simulation_core.services.orchestrator.context import Context
 from movici_simulation_core.services.orchestrator.fsm import (
-    Always,
     Condition,
     FSMDone,
     FSMError,
     State,
-    TransitionsT,
 )
 
 
@@ -44,9 +42,6 @@ class StartInitializingPhase(OrchestratorState):
         self.context.phase_timer.start()
         self.context.log_new_phase("Initializing Phase")
 
-    def transitions(self) -> TransitionsT:
-        return [(Always, ModelsRegistration)]
-
 
 class WaitForModels(OrchestratorState, ABC):
     def run(self):
@@ -58,11 +53,7 @@ class WaitForModels(OrchestratorState, ABC):
 
 
 class ModelsRegistration(WaitForModels):
-    def transitions(self) -> TransitionsT:
-        return [
-            (Failed, StartFinalizingPhase),
-            (AllModelsReady, StartRunningPhase),
-        ]
+    pass
 
 
 class StartRunningPhase(OrchestratorState):
@@ -72,26 +63,15 @@ class StartRunningPhase(OrchestratorState):
         self.context.phase_timer.restart()
         self.context.log_new_phase("Running Phase")
 
-    def transitions(self) -> TransitionsT:
-        return [(Always, NewTime)]
-
 
 class NewTime(OrchestratorState):
     def run(self):
         self.context.log_new_time()
         self.context.queue_models_for_next_time()
 
-    def transitions(self) -> TransitionsT:
-        return [(Always, WaitForResults)]
-
 
 class WaitForResults(WaitForModels):
-    def transitions(self) -> TransitionsT:
-        return [
-            (Failed, StartFinalizingPhase),
-            (AllModelsDone, StartFinalizingPhase),
-            (AllModelsReady, NewTime),
-        ]
+    pass
 
 
 class StartFinalizingPhase(OrchestratorState):
@@ -100,19 +80,12 @@ class StartFinalizingPhase(OrchestratorState):
         self.context.log_new_phase("Finalizing Phase")
         self.context.models.queue_all(QuitMessage(due_to_failure=bool(self.context.failed)))
 
-    def transitions(self) -> TransitionsT:
-        return [(AllModelsReady, EndFinalizingPhase), (Always, FinalizingWaitForModels)]
-
 
 class FinalizingWaitForModels(WaitForModels):
-    def transitions(self) -> TransitionsT:
-        return [(AllModelsReady, EndFinalizingPhase)]
+    pass
 
 
 class EndFinalizingPhase(OrchestratorState):
     def run(self):
         self.context.finalize()
         raise FSMError if self.context.failed else FSMDone
-
-    def transitions(self) -> TransitionsT:
-        return []

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from abc import ABC
 
 from movici_simulation_core.messages import QuitMessage
@@ -43,7 +44,7 @@ class StartInitializingPhase(OrchestratorState):
         self.context.phase_timer.start()
         self.context.log_new_phase("Initializing Phase")
 
-    def transitions(self):
+    def transitions(self) -> TransitionsT:
         return [(Always, ModelsRegistration)]
 
 
@@ -51,7 +52,7 @@ class WaitForModels(OrchestratorState, ABC):
     def run(self):
         ident, msg = yield
 
-        if not (model := self.context.models.get(ident)):
+        if not (model := self.context.models.get(t.cast(bytes, ident))):
             return
         model.recv_event(msg)
 
@@ -78,7 +79,7 @@ class StartRunningPhase(OrchestratorState):
 class NewTime(OrchestratorState):
     def run(self):
         self.context.log_new_time()
-        self.context.timeline.queue_for_next_time(self.context.models)
+        self.context.queue_models_for_next_time()
 
     def transitions(self) -> TransitionsT:
         return [(Always, WaitForResults)]

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import typing as t
 from abc import ABC
 
 from movici_simulation_core.messages import QuitMessage
@@ -47,7 +46,7 @@ class WaitForModels(OrchestratorState, ABC):
     def run(self):
         ident, msg = yield
 
-        if not (model := self.context.models.get(t.cast(bytes, ident))):
+        if not (model := self.context.models.get(ident)):
             return
         model.recv_event(msg)
 

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -48,7 +48,7 @@ class WaitForModels(OrchestratorState, ABC):
 
         if not (model := self.context.models.get(ident)):
             return
-        model.recv_event(msg)
+        self.context.recv_message(model, msg)
 
 
 class ModelsRegistration(WaitForModels):
@@ -77,7 +77,7 @@ class StartFinalizingPhase(OrchestratorState):
     def run(self):
         self.context.phase_timer.restart()
         self.context.log_new_phase("Finalizing Phase")
-        self.context.models.queue_all(QuitMessage(due_to_failure=bool(self.context.failed)))
+        self.context.recv_for_all(QuitMessage(due_to_failure=bool(self.context.failed)))
 
 
 class FinalizingWaitForModels(WaitForModels):

--- a/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
+++ b/packages/simulation-core/src/movici_simulation_core/services/orchestrator/states.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 
-from movici_simulation_core.messages import QuitMessage
+from movici_simulation_core.messages import ModelMessage, QuitMessage
 from movici_simulation_core.services.orchestrator.context import Context
 from movici_simulation_core.services.orchestrator.fsm import (
     Condition,
@@ -43,8 +43,10 @@ class StartInitializingPhase(OrchestratorState):
 
 
 class WaitForModels(OrchestratorState, ABC):
-    def run(self):
-        ident, msg = yield
+    requires_event = True
+
+    def handle_event(self, event: ModelMessage):
+        ident, msg = event
 
         if not (model := self.context.models.get(ident)):
             return

--- a/packages/simulation-core/src/movici_simulation_core/utils/data_mask.py
+++ b/packages/simulation-core/src/movici_simulation_core/utils/data_mask.py
@@ -22,7 +22,6 @@ def validate_mask(data_mask: t.Optional[dict]):
         if df is None:
             return True
 
-        # noinspection PyTypeHints
         if not len(df) or not isinstance(df, shape[depth]):
             return False
         if isinstance(df, dict):
@@ -56,7 +55,7 @@ def ensure_id(mask: t.List[str]):
 
 def masks_overlap(pub: t.Optional[dict], sub: t.Optional[dict]):
     """calculates whether there is overlap between the pub and sub filters of two models. This
-    function assumes that the two filters have been validated using `validate_filter`
+    function assumes that the two filters have been validated using `validate_mask`
     """
     if pub == {} or sub == {}:
         return False

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -50,14 +50,8 @@ def state(state_cls, context):
 
 @pytest.fixture
 def send_message(state, context):
-
     def _send(msg: Message):
-        runner = state.run()
-        runner.send(None)
-        try:
-            runner.send(msg)
-        except StopIteration:
-            pass
+        state.handle_event(msg)
 
     return _send
 
@@ -117,12 +111,7 @@ class TestBusyTransitions:
     @pytest.fixture
     def send_message(self, state):
         def _send(msg: Message):
-            runner = state.run()
-            runner.send(None)
-            try:
-                runner.send(msg)
-            except StopIteration:
-                pass
+            state.handle_event(msg)
 
         return _send
 

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -2,6 +2,7 @@ from unittest.mock import Mock, call
 
 import pytest
 
+from movici_simulation_core.exceptions import InvalidCommand
 from movici_simulation_core.messages import (
     AcknowledgeMessage,
     ErrorMessage,
@@ -97,7 +98,7 @@ class TestWaitingForMessage:
         assert context.failed
 
     def test_invalid_command_raises(self, send_message):
-        with pytest.raises(ValueError):
+        with pytest.raises(InvalidCommand):
             send_message(NewTimeMessage(1))
 
 

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -13,6 +13,8 @@ from movici_simulation_core.messages import (
     UpdateMessage,
 )
 from movici_simulation_core.services.orchestrator.context import (
+    MODEL_BUSY_TRANSITIONS,
+    MODEL_FSM_CONFIG,
     BaseModelState,
     Busy,
     ConnectedModel,
@@ -25,7 +27,7 @@ from movici_simulation_core.services.orchestrator.context import (
     Updating,
     WaitingForMessage,
 )
-from movici_simulation_core.services.orchestrator.fsm import next_state
+from movici_simulation_core.services.orchestrator.fsm import next_state as next_state_
 
 
 @pytest.fixture
@@ -45,18 +47,29 @@ def state(context, state_cls):
 
 @pytest.fixture
 def send_message(state, context):
-    runner = state.run()
-    runner.send(None)
 
     def _send(msg: Message):
-        nonlocal runner
+        runner = state.run()
+        runner.send(None)
         try:
             runner.send(msg)
         except StopIteration:
-            runner = state.run()
-            runner.send(None)
+            pass
 
     return _send
+
+
+@pytest.fixture
+def transitions(state_cls):
+    return MODEL_FSM_CONFIG.states[state_cls]
+
+
+@pytest.fixture
+def next_state(context, transitions):
+    def _calculate_next_state():
+        return next_state_(context, transitions)
+
+    return _calculate_next_state
 
 
 class TestWaitingForMessage:
@@ -84,9 +97,65 @@ class TestWaitingForMessage:
         send_message(msg)
         assert context.failed
 
-    def test_goes_to_process_quit_after_invalid_message(self, send_message, state):
+
+class TestBusyTransitions:
+    @pytest.fixture
+    def state_cls(self):
+        # Use NewTime as a substitute for Busy state, since it has an implementation for a model
+        # response (AcknowledgeMessage)
+        return NewTime
+
+    @pytest.fixture
+    def transitions(self):
+        return MODEL_BUSY_TRANSITIONS
+
+    @pytest.fixture
+    def state(self, state_cls, context):
+        state = state_cls(context)
+        state.on_enter()
+        return state
+
+    @pytest.fixture
+    def send_message(self, state):
+        def _send(msg: Message):
+            runner = state.run()
+            runner.send(None)
+            try:
+                runner.send(msg)
+            except StopIteration:
+                pass
+
+        return _send
+
+    def test_transitions_after_invalid_message(self, send_message, next_state):
         send_message(NewTimeMessage(1))
-        assert next_state(state) == ProcessPendingQuit
+        assert next_state() == ProcessPendingQuit
+
+    def test_transitions_after_error_message(self, send_message, next_state):
+        send_message(ErrorMessage())
+        assert next_state() == Done
+
+    def test_transitions_to_idle_when_no_pending_messages(self, send_message, context, next_state):
+        assert not context.quit
+        assert not context.pending_updates
+        send_message(AcknowledgeMessage())
+        assert next_state() == Idle
+
+    def test_transitions_on_pending_updates(self, send_message, next_state):
+        send_message(UpdateMessage(1))
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingUpdates
+
+    def test_transitions_on_pending_quit(self, send_message, next_state):
+        send_message(QuitMessage())
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingQuit
+
+    def test_quit_has_preference_over_updates(self, send_message, next_state):
+        send_message(QuitMessage())
+        send_message(UpdateMessage(1))
+        send_message(AcknowledgeMessage())
+        assert next_state() == ProcessPendingQuit
 
 
 class TestIdle:
@@ -117,9 +186,9 @@ class TestIdle:
             (QuitMessage(), ProcessPendingQuit),
         ],
     )
-    def test_transitions_to_correct_state(self, msg, expected, send_message, state):
+    def test_transitions_to_correct_state(self, msg, expected, send_message, next_state):
         send_message(msg)
-        assert next_state(state) == expected
+        assert next_state() == expected
 
 
 class TestBusy:
@@ -148,45 +217,6 @@ class TestBusy:
         send_message(ErrorMessage())
         assert not context.quit
         assert not context.pending_updates
-
-
-class TestBusyTransitions:
-    @pytest.fixture
-    def state_cls(self):
-        # Use NewTime as a substitute for Busy state, since it has an implementation for a model
-        # response (AcknowledgeMessage)
-        return NewTime
-
-    @pytest.fixture
-    def context(self, context):
-        context.busy = True
-        return context
-
-    def test_transitions_after_error_message(self, send_message, state):
-        send_message(ErrorMessage())
-        assert next_state(state) == Done
-
-    def test_transitions_to_idle_when_no_pending_messages(self, send_message, state, context):
-        assert not context.quit
-        assert not context.pending_updates
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == Idle
-
-    def test_transitions_on_pending_updates(self, send_message, state, context):
-        send_message(UpdateMessage(1))
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingUpdates
-
-    def test_transitions_on_pending_quit(self, send_message, state, context):
-        send_message(QuitMessage())
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingQuit
-
-    def test_quit_has_preference_over_updates(self, send_message, state, context):
-        send_message(QuitMessage())
-        send_message(UpdateMessage(1))
-        send_message(AcknowledgeMessage())
-        assert next_state(state) == ProcessPendingQuit
 
 
 @pytest.mark.parametrize(

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -84,18 +84,19 @@ class TestWaitingForMessage:
     @pytest.mark.parametrize(
         "msg",
         [
-            NewTimeMessage(1),
-            UpdateMessage(1),
-            QuitMessage(),
             RegistrationMessage(pub=None, sub=None),
             AcknowledgeMessage(),
             ResultMessage(),
             ErrorMessage(),
         ],
     )
-    def test_invalid_message_sets_failed(self, msg, send_message, context):
+    def test_invalid_response_sets_failed(self, msg, send_message, context):
         send_message(msg)
         assert context.failed
+
+    def test_invalid_command_raises(self, send_message):
+        with pytest.raises(ValueError):
+            send_message(NewTimeMessage(1))
 
 
 class TestBusyTransitions:
@@ -127,8 +128,8 @@ class TestBusyTransitions:
 
         return _send
 
-    def test_transitions_after_invalid_message(self, send_message, next_state):
-        send_message(NewTimeMessage(1))
+    def test_transitions_after_invalid_response(self, send_message, next_state):
+        send_message(ResultMessage())
         assert next_state() == ProcessPendingQuit
 
     def test_transitions_after_error_message(self, send_message, next_state):
@@ -195,6 +196,11 @@ class TestBusy:
     @pytest.fixture
     def state_cls(self):
         return Busy
+
+    def test_on_enter_starts_timer(self, context: ConnectedModel):
+        assert not context.timer.running
+        Busy(context).on_enter()
+        assert context.timer.running
 
     def test_sets_quit_message_as_pending(self, send_message, context):
         assert context.quit is None

--- a/packages/simulation-core/tests/services/orchestrator/models/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/models/test_states.py
@@ -41,8 +41,10 @@ def context():
 
 
 @pytest.fixture
-def state(context, state_cls):
-    return state_cls(context)
+def state(state_cls, context):
+    state = state_cls(context)
+    state.on_enter()
+    return state
 
 
 @pytest.fixture
@@ -102,19 +104,14 @@ class TestWaitingForMessage:
 class TestBusyTransitions:
     @pytest.fixture
     def state_cls(self):
-        # Use NewTime as a substitute for Busy state, since it has an implementation for a model
-        # response (AcknowledgeMessage)
-        return NewTime
+        class DummyState(Busy):
+            valid_responses = (ErrorMessage, AcknowledgeMessage)
+
+        return DummyState
 
     @pytest.fixture
     def transitions(self):
         return MODEL_BUSY_TRANSITIONS
-
-    @pytest.fixture
-    def state(self, state_cls, context):
-        state = state_cls(context)
-        state.on_enter()
-        return state
 
     @pytest.fixture
     def send_message(self, state):
@@ -137,7 +134,7 @@ class TestBusyTransitions:
         assert next_state() == Done
 
     def test_transitions_to_idle_when_no_pending_messages(self, send_message, context, next_state):
-        assert not context.quit
+        assert not context.pending_quit
         assert not context.pending_updates
         send_message(AcknowledgeMessage())
         assert next_state() == Idle
@@ -164,15 +161,15 @@ class TestIdle:
     def state_cls(self):
         return Idle
 
-    def test_sends_incoming_new_time_message(self, send_message, context: ConnectedModel):
+    def test_adds_pending_new_time(self, send_message, context: ConnectedModel):
         msg = NewTimeMessage(1)
         send_message(msg)
-        assert context.send.call_args == call(msg)
+        assert context.pending_new_time == msg
 
     def test_adds_quit_to_pending(self, context, send_message):
-        assert context.quit is None
+        assert context.pending_quit is None
         send_message(QuitMessage())
-        assert context.quit == QuitMessage()
+        assert context.pending_quit == QuitMessage()
 
     def test_adds_update_to_pending(self, send_message, context):
         assert context.pending_updates == []
@@ -203,9 +200,9 @@ class TestBusy:
         assert context.timer.running
 
     def test_sets_quit_message_as_pending(self, send_message, context):
-        assert context.quit is None
+        assert context.pending_quit is None
         send_message(QuitMessage())
-        assert context.quit == QuitMessage()
+        assert context.pending_quit == QuitMessage()
 
     def test_adds_update_message_as_pending(self, send_message, context):
         context.pending_updates = [UpdateMessage(1)]
@@ -218,10 +215,10 @@ class TestBusy:
         assert context.failed
 
     def test_reset_pending_after_error(self, send_message, context):
-        context.quit = QuitMessage()
+        context.pending_quit = QuitMessage()
         context.pending_updates = [UpdateMessage(1)]
         send_message(ErrorMessage())
-        assert not context.quit
+        assert not context.pending_quit
         assert not context.pending_updates
 
 
@@ -229,7 +226,6 @@ class TestBusy:
     "state_cls, msg",
     [
         (Registration, RegistrationMessage(None, None)),
-        (NewTime, AcknowledgeMessage()),
         (Updating, ResultMessage()),
     ],
 )
@@ -257,8 +253,17 @@ class TestRegistration:
 
 class TestNewTime:
     @pytest.fixture
+    def context(self, context):
+        context.pending_new_time = NewTimeMessage(1)
+        return context
+
+    @pytest.fixture
     def state_cls(self):
         return NewTime
+
+    def test_sends_pending_new_time_and_resets(self, context, send_message):
+        assert context.send.call_args == call(NewTimeMessage(1))
+        assert context.pending_new_time is None
 
     def test_acknowledge_is_valid(self, send_message, context):
         send_message(AcknowledgeMessage())

--- a/packages/simulation-core/tests/services/orchestrator/test_connected_model.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_connected_model.py
@@ -18,7 +18,9 @@ def timeline():
 
 def get_model(name="dummy", timeline=None, send=None, **kwargs):
     send = send or Mock()
-    return ConnectedModel(name, timeline, send, **kwargs)
+    model = ConnectedModel(name, timeline, send, **kwargs)
+    model.start()
+    return model
 
 
 class TestConnectedModel:
@@ -63,14 +65,6 @@ class TestConnectedModel:
         msg = UpdateMessage(1)
         model.recv_event(msg)
         assert model.send.call_args == call(msg)
-
-    def test_send_command_starts_timer(self, model):
-        model.send_command(UpdateMessage(1))
-        assert model.timer.running
-
-    def test_send_command_marks_model_as_waiting(self, model):
-        model.send_command(UpdateMessage(1))
-        assert model.busy
 
     def test_response_stops_timer_and_busy(self, running_model):
         running_model.recv_event(ResultMessage())

--- a/packages/simulation-core/tests/services/orchestrator/test_context.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_context.py
@@ -102,8 +102,8 @@ class TestContext:
         "failures,loglevel,msg_endswith",
         [
             ([], "info", "successfully finished"),
-            (["one"], "error", "model 'one'"),
-            (["one", "two"], "error", "models 'one', 'two'"),
+            (["one"], "error", "component 'one'"),
+            (["one", "two"], "error", "components 'one', 'two'"),
         ],
     )
     def test_logs_finalize_message(self, failures, loglevel, msg_endswith, context):
@@ -125,7 +125,6 @@ class TestContext:
         ],
     )
     def test_queue_for_next_time(self, next_a, next_b, exp_a, exp_b, make_context):
-
         context = make_context(
             timeline=TimelineController(start=0, end=20, current_time=0),
         )

--- a/packages/simulation-core/tests/services/orchestrator/test_context.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_context.py
@@ -1,7 +1,8 @@
-from unittest.mock import Mock, call
+from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
 
 import pytest
 
+from movici_simulation_core.exceptions import InvalidCommand
 from movici_simulation_core.messages import NewTimeMessage, UpdateMessage
 from movici_simulation_core.services.orchestrator.context import (
     Context,
@@ -52,6 +53,66 @@ class TestTimelineController:
 
 
 class TestContext:
+    @pytest.fixture
+    def make_context(self):
+        sentinel = object()
+
+        def _make(
+            models=None,
+            timeline=sentinel,
+            phase_timer=sentinel,
+            global_timer=sentinel,
+            logger=sentinel,
+            **kwargs,
+        ):
+            a, b = Mock(), Mock()
+            return Context(
+                models=models if models is not None else ModelCollection(a=a, b=b),
+                timeline=timeline if timeline is not sentinel else Mock(),
+                phase_timer=phase_timer if phase_timer is not sentinel else Mock(),
+                global_timer=global_timer if global_timer is not sentinel else Mock(),
+                logger=logger if logger is not sentinel else Mock(),
+                **kwargs,
+            )
+
+        return _make
+
+    @pytest.fixture
+    def context(self, make_context):
+        return make_context()
+
+    def test_logs_on_global_timer_reset(self, make_context):
+        context = make_context(global_timer=None, phase_timer=None)
+        context.global_timer.reset()
+        assert context.logger.info.call_args == call("Total elapsed time: 0.0")
+
+    def test_logs_on_phase_timer_reset(self, make_context):
+        context = make_context(global_timer=None, phase_timer=None)
+        context.phase_timer.reset()
+        assert context.logger.info.call_args == call("Phase finished in 0.0 seconds")
+
+    def test_resets_timers_on_finalize(self, make_context):
+        context = make_context(models=MagicMock(ModelCollection))
+        context.finalize()
+        assert context.phase_timer.reset.call_count == 1
+        assert context.global_timer.reset.call_count == 1
+        assert context.models.reset_model_timers.call_count == 1
+
+    @pytest.mark.parametrize(
+        "failures,loglevel,msg_endswith",
+        [
+            ([], "info", "successfully finished"),
+            (["one"], "error", "model 'one'"),
+            (["one", "two"], "error", "models 'one', 'two'"),
+        ],
+    )
+    def test_logs_finalize_message(self, failures, loglevel, msg_endswith, context):
+        with patch.object(Context, "failed", new_callable=PropertyMock) as failed:
+            failed.return_value = failures
+            context.finalize()
+
+        assert getattr(context.logger, loglevel).call_args[0][0].endswith(msg_endswith)
+
     @pytest.mark.parametrize(
         "next_a, next_b, exp_a, exp_b",
         [
@@ -63,13 +124,13 @@ class TestContext:
             (None, 2, [NewTimeMessage(2)], [NewTimeMessage(2), UpdateMessage(2)]),
         ],
     )
-    def test_queue_for_next_time(self, next_a, next_b, exp_a, exp_b):
-        a, b = Mock(), Mock()
+    def test_queue_for_next_time(self, next_a, next_b, exp_a, exp_b, make_context):
 
-        context = Context(
-            models=ModelCollection(a=a, b=b),
+        context = make_context(
             timeline=TimelineController(start=0, end=20, current_time=0),
         )
+        a = context.models["a"]
+        b = context.models["b"]
         a.next_time = next_a
         b.next_time = next_b
 
@@ -77,3 +138,18 @@ class TestContext:
 
         assert a.recv_event.call_args_list == [call(msg) for msg in exp_a]
         assert b.recv_event.call_args_list == [call(msg) for msg in exp_b]
+
+    def test_recv_for_all(self, context):
+        assert len(context.models) > 0
+        message = object()
+        context.recv_for_all(message)
+        for model in context.models.values():
+            assert model.recv_event.call_args == call(message)
+
+    def test_invalid_command_sets_failed(self, make_context):
+        model_a = Mock()
+        model_a.recv_event.side_effect = InvalidCommand
+        context: Context = make_context(models=ModelCollection(a=model_a))
+        context.recv_message(model_a, UpdateMessage(12))
+        assert context.orchestrator_failed
+        assert "orchestrator" in context.failed

--- a/packages/simulation-core/tests/services/orchestrator/test_context.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_context.py
@@ -4,6 +4,7 @@ import pytest
 
 from movici_simulation_core.messages import NewTimeMessage, UpdateMessage
 from movici_simulation_core.services.orchestrator.context import (
+    Context,
     ModelCollection,
     TimelineController,
 )
@@ -49,26 +50,30 @@ class TestTimelineController:
         timeline = TimelineController(start=1, end=20, current_time=10)
         assert timeline._get_validated_next_time(10) == 10
 
+
+class TestContext:
     @pytest.mark.parametrize(
         "next_a, next_b, exp_a, exp_b",
         [
             (0, 1, [UpdateMessage(0)], []),
             (2, 1, [NewTimeMessage(1)], [NewTimeMessage(1), UpdateMessage(1)]),
             (1, 2, [NewTimeMessage(1), UpdateMessage(1)], [NewTimeMessage(1)]),
+            (2, 2, [NewTimeMessage(2), UpdateMessage(2)], [NewTimeMessage(2), UpdateMessage(2)]),
             (2, None, [NewTimeMessage(2), UpdateMessage(2)], [NewTimeMessage(2)]),
             (None, 2, [NewTimeMessage(2)], [NewTimeMessage(2), UpdateMessage(2)]),
         ],
     )
     def test_queue_for_next_time(self, next_a, next_b, exp_a, exp_b):
-        timeline = TimelineController(start=0, end=20, current_time=0)
         a, b = Mock(), Mock()
-        models = ModelCollection(
-            a=a,
-            b=b,
+
+        context = Context(
+            models=ModelCollection(a=a, b=b),
+            timeline=TimelineController(start=0, end=20, current_time=0),
         )
         a.next_time = next_a
         b.next_time = next_b
 
-        timeline.queue_for_next_time(models)
+        context.queue_models_for_next_time()
+
         assert a.recv_event.call_args_list == [call(msg) for msg in exp_a]
         assert b.recv_event.call_args_list == [call(msg) for msg in exp_b]

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -61,6 +61,29 @@ def test_calls_on_enter_when_starting():
     assert StateA.on_enter.call_count == 1
 
 
+def test_calls_on_enter_when_transitioning():
+    class StateA(DummyState):
+        pass
+
+    class StateB(DummyState):
+        on_enter = Mock()
+        is_final = True
+
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
+    fsm.start()
+    assert StateB.on_enter.call_count == 1
+
+
 def test_fsm_runs_a_state():
     class StateA(DummyState):
         is_final = True

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -9,8 +9,8 @@ from movici_simulation_core.services.orchestrator.fsm import (
     Always,
     Condition,
     Event,
+    FSMConfig,
     State,
-    TransitionsT,
 )
 
 
@@ -52,7 +52,11 @@ def test_calls_on_enter_when_starting():
         is_final = True
         on_enter = Mock()
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(initial_state=StateA, states={StateA: []}),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert StateA.on_enter.call_count == 1
 
@@ -61,28 +65,40 @@ def test_fsm_runs_a_state():
     class StateA(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(initial_state=StateA, states={StateA: []}),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA]
 
 
 def test_fsm_does_a_transition():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA, StateB]
 
 
 def test_fsm_calls_on_enter_on_transition():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(DummyState):
         is_final = True
@@ -90,7 +106,17 @@ def test_fsm_calls_on_enter_on_transition():
 
     assert StateA.on_enter is not StateB.on_enter
 
-    fsm = FSM(StateA, context=DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert StateB.on_enter.call_count == 1
 
@@ -102,7 +128,16 @@ def test_fsm_doensnt_call_on_enter_when_not_transitioning():
             self.is_final = True
 
     context = DummyContext()
-    fsm = FSM(StateA, context=context, raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [],
+            },
+        ),
+        context=context,
+        raise_on_done=False,
+    )
     fsm.start()
     assert context.states == [StateA, StateA]
     assert StateA.on_enter.call_count == 1
@@ -113,7 +148,16 @@ def test_evented_state_handles_event():
         is_final = True
 
     event = Event()
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     fsm.send(event)
     assert fsm.context.events == [event]
@@ -121,13 +165,22 @@ def test_evented_state_handles_event():
 
 def test_fsm_runs_until_event_required():
     class StateA(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateB)]
+        pass
 
     class StateB(EventState):
         pass
 
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            initial_state=StateA,
+            states={
+                StateA: [(Always, StateB)],
+                StateB: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     assert fsm.context.states == [StateA]
     assert isinstance(fsm.state, StateB)
@@ -141,17 +194,31 @@ def test_fsm_does_more_complex_transitions():
             return StateB not in self.context.states
 
     class StateA(EventState):
-        def transitions(self) -> TransitionsT:
-            return [(HaventTransitionedToB, StateB), (Always, StateC)]
+        pass
 
     class StateB(DummyState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, StateA)]
+        pass
 
     class StateC(DummyState):
         is_final = True
 
-    fsm = FSM(StateA, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            StateA,
+            states={
+                StateA: [
+                    (HaventTransitionedToB, StateB),
+                    (Always, StateC),
+                ],
+                StateB: [
+                    (Always, StateA),
+                ],
+                StateC: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     one = Event()
     two = Event()
@@ -166,7 +233,14 @@ def test_fsm_raises_when_trying_to_send_when_done():
     class DoneState(DummyState):
         is_final = True
 
-    fsm = FSM(DoneState, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            DoneState,
+            states={DoneState: []},
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
     with pytest.raises(FSMDone):
         fsm.send(Event())
@@ -174,13 +248,22 @@ def test_fsm_raises_when_trying_to_send_when_done():
 
 def test_fsm_raises_when_trying_to_start_twice():
     class SomeState(EventState):
-        def transitions(self) -> TransitionsT:
-            return [(Always, FinalState)]
+        pass
 
     class FinalState(DummyState):
         is_final = True
 
-    fsm = FSM(SomeState, DummyContext(), raise_on_done=False)
+    fsm = FSM(
+        FSMConfig(
+            SomeState,
+            states={
+                SomeState: [(Always, FinalState)],
+                FinalState: [],
+            },
+        ),
+        context=DummyContext(),
+        raise_on_done=False,
+    )
     fsm.start()
 
     with pytest.raises(FSMStarted):

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -299,3 +299,49 @@ def test_fsm_raises_when_trying_to_start_twice():
 
     with pytest.raises(FSMDone):
         fsm.start()
+
+
+class TestFSMConfig:
+    def test_validates_initial_state(self):
+        class StateA(State):
+            def run(self):
+                pass
+
+        class StateB(State):
+            def run(self):
+                pass
+
+        with pytest.raises(ValueError, match="StateA is not a member of 'states"):
+            FSMConfig(initial_state=StateA, states={StateB: []})
+
+    def test_all_transition_states_are_given(self):
+        class StateA(State):
+            def run(self):
+                pass
+
+        class StateB(State):
+            def run(self):
+                pass
+
+        with pytest.raises(ValueError, match="State StateB was mentioned in a transition"):
+            FSMConfig(initial_state=StateA, states={StateA: [(Always, StateB)]})
+
+    def test_validates_require_event_state_has_handle_event_method(self):
+        class StateA(State):
+            requires_event = True
+
+            def run(self):
+                pass
+
+        with pytest.raises(ValueError, match="did not implement a 'handle_event' method"):
+            FSMConfig(initial_state=StateA, states={StateA: []})
+
+    def test_validates_not_require_event_state_has_run_method(self):
+        class StateA(State):
+            requires_event = False
+
+            def handle_event(self, event):
+                pass
+
+        with pytest.raises(ValueError, match="did not implement a 'run' method"):
+            FSMConfig(initial_state=StateA, states={StateA: []})

--- a/packages/simulation-core/tests/services/orchestrator/test_fsm.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_fsm.py
@@ -8,10 +8,13 @@ from movici_simulation_core.services.orchestrator.fsm import (
     FSM,
     Always,
     Condition,
-    Event,
     FSMConfig,
     State,
 )
+
+
+class Event:
+    pass
 
 
 @dataclass
@@ -37,10 +40,10 @@ def reset_mock():
 
 
 class EventState(State[DummyContext]):
+    requires_event = True
     is_final = False
 
-    def run(self):
-        event = yield
+    def handle_event(self, event):
         self.context.states.append(type(self))
         self.context.events.append(event)
         if self.is_final:
@@ -182,7 +185,7 @@ def test_evented_state_handles_event():
         raise_on_done=False,
     )
     fsm.start()
-    fsm.send(event)
+    fsm.handle_event(event)
     assert fsm.context.events == [event]
 
 
@@ -245,8 +248,8 @@ def test_fsm_does_more_complex_transitions():
     fsm.start()
     one = Event()
     two = Event()
-    fsm.send(one)
-    fsm.send(two)
+    fsm.handle_event(one)
+    fsm.handle_event(two)
 
     assert fsm.context.states == [StateA, StateB, StateA, StateC]
     assert fsm.context.events == [one, two]
@@ -266,7 +269,7 @@ def test_fsm_raises_when_trying_to_send_when_done():
     )
     fsm.start()
     with pytest.raises(FSMDone):
-        fsm.send(Event())
+        fsm.handle_event(Event())
 
 
 def test_fsm_raises_when_trying_to_start_twice():
@@ -292,7 +295,7 @@ def test_fsm_raises_when_trying_to_start_twice():
     with pytest.raises(FSMStarted):
         fsm.start()
 
-    fsm.send(Event())
+    fsm.handle_event(Event())
 
     with pytest.raises(FSMDone):
         fsm.start()

--- a/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
@@ -1,6 +1,6 @@
 import logging
 import typing as t
-from unittest.mock import MagicMock, Mock, PropertyMock, call, patch
+from unittest.mock import MagicMock, Mock, call
 
 import pytest
 
@@ -25,8 +25,16 @@ from movici_simulation_core.services.orchestrator.context import (
     ModelCollection,
     TimelineController,
 )
-from movici_simulation_core.services.orchestrator.fsm import FSM
-from movici_simulation_core.services.orchestrator.states import StartInitializingPhase
+from movici_simulation_core.services.orchestrator.fsm import FSM, Always, FSMConfig
+from movici_simulation_core.services.orchestrator.states import (
+    AllModelsReady,
+    EndFinalizingPhase,
+    Failed,
+    FinalizingWaitForModels,
+    OrchestratorState,
+    StartFinalizingPhase,
+    StartInitializingPhase,
+)
 from movici_simulation_core.settings import Settings
 
 
@@ -40,67 +48,6 @@ def get_model(name="dummy", timeline=None, send=None, **kwargs):
     model = ConnectedModel(name, timeline, send, **kwargs)
     model.recv_event = Mock()
     return model
-
-
-class TestContext:
-    @pytest.fixture
-    def make_context(self):
-        sentinel = object()
-
-        def _make(
-            models=None,
-            timeline=sentinel,
-            phase_timer=sentinel,
-            global_timer=sentinel,
-            logger=sentinel,
-            **kwargs,
-        ):
-            return Context(
-                models=models if models is not None else ModelCollection(),
-                timeline=timeline if timeline is not sentinel else Mock(),
-                phase_timer=phase_timer if phase_timer is not sentinel else Mock(),
-                global_timer=global_timer if global_timer is not sentinel else Mock(),
-                logger=logger if logger is not sentinel else Mock(),
-                **kwargs,
-            )
-
-        return _make
-
-    @pytest.fixture
-    def context(self, make_context):
-        return make_context()
-
-    def test_logs_on_global_timer_reset(self, make_context):
-        context = make_context(global_timer=None, phase_timer=None)
-        context.global_timer.reset()
-        assert context.logger.info.call_args == call("Total elapsed time: 0.0")
-
-    def test_logs_on_phase_timer_reset(self, make_context):
-        context = make_context(global_timer=None, phase_timer=None)
-        context.phase_timer.reset()
-        assert context.logger.info.call_args == call("Phase finished in 0.0 seconds")
-
-    def test_resets_timers_on_finalize(self, make_context):
-        context = make_context(models=MagicMock(ModelCollection))
-        context.finalize()
-        assert context.phase_timer.reset.call_count == 1
-        assert context.global_timer.reset.call_count == 1
-        assert context.models.reset_model_timers.call_count == 1
-
-    @pytest.mark.parametrize(
-        "failures,loglevel,msg_endswith",
-        [
-            ([], "info", "successfully finished"),
-            (["one"], "error", "model 'one'"),
-            (["one", "two"], "error", "models 'one', 'two'"),
-        ],
-    )
-    def test_logs_finalize_message(self, failures, loglevel, msg_endswith, context):
-        with patch.object(Context, "failed", new_callable=PropertyMock) as failed:
-            failed.return_value = failures
-            context.finalize()
-
-        assert getattr(context.logger, loglevel).call_args[0][0].endswith(msg_endswith)
 
 
 class TestModelCollection:
@@ -136,12 +83,6 @@ class TestModelCollection:
         models["a"].next_time = next_a
         models["b"].next_time = next_b
         assert models.next_time == expected
-
-    def test_queue_all(self, models):
-        message = object()
-        models.queue_all(message)
-        for model in models.values():
-            assert model.recv_event.call_args == call(message)
 
     def test_determine_interdependency_publishes_to(self, timeline):
         """
@@ -216,13 +157,13 @@ def message_socket(socket):
 
 
 @pytest.fixture
-def orchestrator(config, message_socket, settings):
-    return _create_orchestrator(config, message_socket, settings)
+def orchestrator(create_orchestrator, config):
+    return create_orchestrator(config)
 
 
 @pytest.fixture
-def setup_orchestrator(message_socket, settings):
-    def make_orchestrator(models: t.Sequence[str]):
+def setup_orchestrator(create_orchestrator):
+    def make_orchestrator(models: t.Sequence[str], orchestrator_cls=Orchestrator):
         config = {
             "name": "test_scenario",
             "simulation_info": {
@@ -235,23 +176,27 @@ def setup_orchestrator(message_socket, settings):
             "models": [{"name": model, "type": model} for model in models],
         }
 
-        return _create_orchestrator(config, message_socket, settings)
+        return create_orchestrator(config, orchestrator_cls=orchestrator_cls)
 
     return make_orchestrator
 
 
 @pytest.fixture
-def settings(config):
+def settings():
     return Settings(name="orchestrator")
 
 
-def _create_orchestrator(config, socket, settings):
-    settings.apply_scenario_config(config)
-    orchestrator = Orchestrator()
-    logger = logging.getLogger()
-    stream = Stream(socket, logger)
-    orchestrator.setup(logger=logger, stream=stream, settings=settings)
-    return orchestrator
+@pytest.fixture
+def create_orchestrator(message_socket, settings):
+    def _create(config, orchestrator_cls=Orchestrator):
+        settings.apply_scenario_config(config)
+        orchestrator = orchestrator_cls()
+        logger = logging.getLogger()
+        stream = Stream(message_socket, logger)
+        orchestrator.setup(logger=logger, stream=stream, settings=settings)
+        return orchestrator
+
+    return _create
 
 
 @pytest.fixture
@@ -323,9 +268,13 @@ def run_orchestrator(setup_orchestrator, socket):
         msg_type, *content = payload
         return ident.decode(), load_message(msg_type, *content)
 
-    def _run_fsm(models: t.Sequence[str], updates: t.Sequence[t.Tuple[str, Message]]):
+    def _run_fsm(
+        models: t.Sequence[str],
+        updates: t.Sequence[t.Tuple[str, Message]],
+        orchestrator_cls=Orchestrator,
+    ):
         incoming = map(message_to_bytes, updates)
-        orchestrator = setup_orchestrator(models)
+        orchestrator = setup_orchestrator(models, orchestrator_cls=orchestrator_cls)
         socket.recv_multipart.side_effect = incoming
         try:
             orchestrator.run()
@@ -732,4 +681,62 @@ def test_acknowledge_message_doesnt_trigger_pending_model_when_dependency_should
         ("a", QuitMessage()),
         ("b", QuitMessage()),
         ("c", QuitMessage()),
+    ]
+
+
+def test_crashing_model_shuts_down_simulation_during_registration(run_orchestrator):
+    results = run_orchestrator(
+        ["a", "b"],
+        [
+            ("a", ErrorMessage()),
+            ("b", RegistrationMessage(pub=None, sub=None)),
+            ("b", AcknowledgeMessage()),
+        ],
+    )
+    assert results == [
+        ("b", QuitMessage(due_to_failure=True)),
+    ]
+
+
+def test_invalid_command_gracefully_shuts_down_models(run_orchestrator):
+    class IncorrectState(OrchestratorState):
+        def run(self):
+            self.context.recv_for_all(UpdateMessage(0))
+
+    failing_fsm_config = FSMConfig(
+        initial_state=IncorrectState,
+        states={
+            IncorrectState: [
+                (Failed, StartFinalizingPhase),
+            ],
+            StartFinalizingPhase: [
+                (AllModelsReady, EndFinalizingPhase),
+                (Always, FinalizingWaitForModels),
+            ],
+            FinalizingWaitForModels: [
+                (AllModelsReady, EndFinalizingPhase),
+            ],
+            EndFinalizingPhase: [],
+        },
+    )
+
+    class FailingOrchestrator(Orchestrator):
+        def _setup_fsm(self):
+            self.fsm = FSM(failing_fsm_config, context=self.context)
+            self.stream.set_handler(self.fsm.send)
+
+    results = run_orchestrator(
+        ["a", "b"],
+        [
+            ("a", RegistrationMessage(pub={}, sub={})),
+            ("b", RegistrationMessage(pub={}, sub={})),
+            # Models acknowledge Quitmessage
+            ("a", AcknowledgeMessage()),
+            ("b", AcknowledgeMessage()),
+        ],
+        orchestrator_cls=FailingOrchestrator,
+    )
+    assert results == [
+        ("a", QuitMessage()),
+        ("b", QuitMessage()),
     ]

--- a/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
@@ -547,6 +547,24 @@ def test_invalid_response_in_finalizing_doesnt_trigger_another_quit(run_orchestr
     ]
 
 
+def test_invalid_response_after_another_model_crashes_terminates_the_model(run_orchestrator):
+    results = run_orchestrator(
+        ["model_a", "model_b"],
+        [
+            ("model_a", RegistrationMessage(pub={"a": None}, sub={})),
+            ("model_b", RegistrationMessage(pub={}, sub={"a": None})),
+            ("model_a", ErrorMessage()),
+            ("model_b", ResultMessage()),  # should have been AcknowledgeMessage
+            ("model_b", AcknowledgeMessage()),  # acknowledge the QuitMessage
+        ],
+    )
+    assert results == [
+        ("model_a", NewTimeMessage(0)),
+        ("model_b", NewTimeMessage(0)),
+        ("model_b", QuitMessage(due_to_failure=True)),  # send the original QuitMessage
+    ]
+
+
 def test_acknowledge_message_triggers_pending_model_with_NoUpdateMessage(run_orchestrator):
     results = run_orchestrator(
         ["a", "b", "c"],

--- a/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_orchestrator.py
@@ -723,7 +723,7 @@ def test_invalid_command_gracefully_shuts_down_models(run_orchestrator):
     class FailingOrchestrator(Orchestrator):
         def _setup_fsm(self):
             self.fsm = FSM(failing_fsm_config, context=self.context)
-            self.stream.set_handler(self.fsm.send)
+            self.stream.set_handler(self.fsm.handle_event)
 
     results = run_orchestrator(
         ["a", "b"],
@@ -737,6 +737,6 @@ def test_invalid_command_gracefully_shuts_down_models(run_orchestrator):
         orchestrator_cls=FailingOrchestrator,
     )
     assert results == [
-        ("a", QuitMessage()),
-        ("b", QuitMessage()),
+        ("a", QuitMessage(due_to_failure=True)),
+        ("b", QuitMessage(due_to_failure=True)),
     ]

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, call
 
 import pytest
 
-from movici_simulation_core.exceptions import SimulationExit
 from movici_simulation_core.messages import QuitMessage
 from movici_simulation_core.services.orchestrator.context import ConnectedModel, ModelCollection
 from movici_simulation_core.services.orchestrator.fsm import FSMDone, FSMError
@@ -69,14 +68,17 @@ class TestWaitForModels(BaseTestState):
         send_message()
         assert model_mock.recv_event.call_args == call(event)
 
-    def test_quits_when_model_crashes(self, send_message, model_mock, state):
-        model_mock.handle_message.side_effect = SimulationExit
-        send_message(name="model_a")
-        assert state.context.failed == ["model_a"]
+    def test_ignores_unknown_models(self, send_message, context):
+        context.recv_message = Mock()
 
-    def test_ignores_unknown_models(self, send_message, model_mock):
+        # a known model is called
+        send_message(name="model_a")
+        assert context.recv_message.call_count == 1
+        context.recv_message.reset_mock()
+
+        # an unknown model is ignored
         send_message(name="unknown")
-        assert model_mock.handle_message.call_count == 0
+        assert context.recv_message.call_count == 0
 
 
 class TestStartRunningPhase(BaseTestState):

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -114,8 +114,9 @@ class TestStartFinalizingPhase(BaseTestState):
         assert context.phase_timer.restart.call_count == 1
 
     def test_replaces_queue_with_quit_message(self, state, context):
+        context.recv_for_all = Mock()
         state.run()
-        assert type(context.models.queue_all.call_args[0][0]) is QuitMessage
+        assert type(context.recv_for_all.call_args[0][0]) is QuitMessage
 
 
 class TestEndFinalizingPhase(BaseTestState):

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -97,9 +97,13 @@ class TestStartRunningPhase(BaseTestState):
 class TestNewTime(BaseTestState):
     state_cls = NewTime
 
+    @pytest.fixture
+    def context(self):
+        return Mock()
+
     def test_queues_models(self, state, context):
         state.run()
-        assert context.timeline.queue_for_next_time.call_args == call(context.models)
+        assert context.queue_models_for_next_time.call_count == 1
 
 
 class TestStartFinalizingPhase(BaseTestState):

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -5,7 +5,7 @@ import pytest
 from movici_simulation_core.exceptions import SimulationExit
 from movici_simulation_core.messages import QuitMessage
 from movici_simulation_core.services.orchestrator.context import ConnectedModel, ModelCollection
-from movici_simulation_core.services.orchestrator.fsm import FSMDone, FSMError, send_silent
+from movici_simulation_core.services.orchestrator.fsm import FSMDone, FSMError
 from movici_simulation_core.services.orchestrator.states import (
     EndFinalizingPhase,
     NewTime,
@@ -56,14 +56,11 @@ class TestWaitForModels(BaseTestState):
 
     @pytest.fixture
     def send_message(self, state, event):
-        runner = state.run()
-        send_silent(runner, None)
 
         def _send(name=None, msg=None):
             msg = msg or event
             name = name or "model_a"
-            send_silent(runner, (name, msg))
-            return runner
+            state.handle_event((name, msg))
 
         return _send
 

--- a/packages/simulation-core/tests/services/orchestrator/test_states.py
+++ b/packages/simulation-core/tests/services/orchestrator/test_states.py
@@ -18,7 +18,7 @@ from movici_simulation_core.services.orchestrator.states import (
 
 
 class BaseTestState:
-    state_cls = OrchestratorState
+    state_cls: type[OrchestratorState]
 
     @pytest.fixture
     def state(self, context):


### PR DESCRIPTION
Describe your changes
--------------------
In order to optimize the Orchestrator for a non-distributed runner (and potentially other run modes), we need to hook into the internals of the orchestrator FSMs. Currently the Orchestrator and ConnectedModel FSMs are hard coded, making it hard to change which states connect to each other. This PR decouples the transitions from the state classes and allows the FSM to be configured using an `FSMConfig` class that contains the states and the transition (conditions) between them.

Furthermore this PR

* improves typing
* refactors/simplifies/makes things more logical

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to
 re-/sublicense my contribution
