### PR TITLE
Add enum value/string helpers to AttributeOptions

### DIFF
--- a/packages/simulation-core/src/movici_simulation_core/core/attribute.py
+++ b/packages/simulation-core/src/movici_simulation_core/core/attribute.py
@@ -116,6 +116,41 @@ class AttributeOptions(t.Generic[T]):
             )
         return self._enum
 
+    def get_enum_value(self, string: str, case_sensitive: bool = True) -> int:
+        """Return the integer index of the enum member *string*.
+
+        :param string: the enum keyword to look up
+        :param case_sensitive: when ``False``, match case-insensitively
+        :raises ValueError: if no enumeration is configured or *string* is not a member
+        """
+        if self.enum_values is None:
+            raise ValueError("No enumeration is configured for this attribute")
+        if case_sensitive:
+            if string in self.enum_values:
+                return self.enum_values.index(string)
+        else:
+            target = string.casefold()
+            for idx, val in enumerate(self.enum_values):
+                if val.casefold() == target:
+                    return idx
+        raise ValueError(
+            f"'{string}' is not a member of enum '{self.enum_name}': {self.enum_values}"
+        )
+
+    def get_enum_string(self, value: int) -> str:
+        """Return the enum member string for integer index *value*.
+
+        :raises ValueError: if no enumeration is configured or *value* is out of range
+        """
+        if self.enum_values is None:
+            raise ValueError("No enumeration is configured for this attribute")
+        if not 0 <= value < len(self.enum_values):
+            raise ValueError(
+                f"Enum value {value} is out of range for enum '{self.enum_name}' "
+                f"({len(self.enum_values)} members)"
+            )
+        return self.enum_values[value]
+
 
 class Attribute(abc.ABC):
     def __init__(
@@ -179,6 +214,16 @@ class Attribute(abc.ABC):
 
     def get_enumeration(self):
         return self.options.get_enumeration()
+
+    def get_enum_value(self, string: str, case_sensitive: bool = True) -> int:
+        """Return the integer index of the enum member *string* (see
+        :meth:`AttributeOptions.get_enum_value`)."""
+        return self.options.get_enum_value(string, case_sensitive=case_sensitive)
+
+    def get_enum_string(self, value: int) -> str:
+        """Return the enum member string for integer index *value* (see
+        :meth:`AttributeOptions.get_enum_string`)."""
+        return self.options.get_enum_string(value)
 
     @abc.abstractmethod
     def __len__(self):

--- a/packages/simulation-core/tests/data_tracker/test_attribute.py
+++ b/packages/simulation-core/tests/data_tracker/test_attribute.py
@@ -541,3 +541,38 @@ class TestEnum:
         enum = attribute.get_enumeration()
         assert enum.a == 0
         assert enum.b == 1
+
+    @pytest.mark.parametrize("enum_values", (["FREE", "FIXED", "TIDAL"],))
+    def test_get_enum_value(self, attribute: UniformAttribute):
+        assert attribute.get_enum_value("FREE") == 0
+        assert attribute.get_enum_value("TIDAL") == 2
+
+    @pytest.mark.parametrize("enum_values", (["FREE", "FIXED"],))
+    def test_get_enum_value_case_insensitive(self, attribute: UniformAttribute):
+        assert attribute.get_enum_value("fixed", case_sensitive=False) == 1
+        with pytest.raises(ValueError, match="not a member"):
+            attribute.get_enum_value("fixed")  # case-sensitive by default
+
+    @pytest.mark.parametrize("enum_values", (["FREE", "FIXED"],))
+    def test_get_enum_value_unknown_raises(self, attribute: UniformAttribute):
+        with pytest.raises(ValueError, match="not a member"):
+            attribute.get_enum_value("NOPE")
+
+    @pytest.mark.parametrize("enum_values", (["FREE", "FIXED", "TIDAL"],))
+    def test_get_enum_string(self, attribute: UniformAttribute):
+        assert attribute.get_enum_string(0) == "FREE"
+        assert attribute.get_enum_string(2) == "TIDAL"
+
+    @pytest.mark.parametrize("enum_values", (["FREE", "FIXED"],))
+    def test_get_enum_string_out_of_range_raises(self, attribute: UniformAttribute):
+        with pytest.raises(ValueError, match="out of range"):
+            attribute.get_enum_string(5)
+        with pytest.raises(ValueError, match="out of range"):
+            attribute.get_enum_string(-1)
+
+    def test_enum_helpers_raise_without_enumeration(self, attribute: UniformAttribute):
+        # enum_values defaults to None for this fixture
+        with pytest.raises(ValueError, match="No enumeration"):
+            attribute.get_enum_value("x")
+        with pytest.raises(ValueError, match="No enumeration"):
+            attribute.get_enum_string(0)


### PR DESCRIPTION
## Summary

Adds two small helpers for converting between an enum attribute's keyword string and its integer index, on `AttributeOptions` and proxied on `Attribute`:

- `get_enum_value(string, case_sensitive=True) -> int`
- `get_enum_string(value) -> str`

Both raise a clear `ValueError` when no enumeration is configured, the string is not a member, or the index is out of range. `get_enum_value` accepts a `case_sensitive` flag for case-insensitive lookups.

## Motivation

These came out of the review of the urban-drainage model PR (#137): models that map an integer enum attribute to/from a SWMM/engine keyword currently either hand-roll `attribute.options.enum_values[i]` or build a throwaway class via `get_enumeration()`. A pair of explicit, validated methods is cleaner and reusable (drinking-water and urban-drainage both do this kind of conversion). `get_enumeration()` is left in place (it's only used in tests); it can be deprecated/removed in a follow-up if desired.

## Tests

Added cases to `TestEnum` in `tests/data_tracker/test_attribute.py` covering value↔string conversion, the `case_sensitive` flag, unknown-member and out-of-range (incl. negative) errors, and the no-enumeration error. `test_attribute.py` passes (86 tests).