### PR TITLE
Fix bug where input data may produce incorrectly shaped attribute arrays

### DIFF
--- a/packages/simulation-core/src/movici_simulation_core/core/data_format.py
+++ b/packages/simulation-core/src/movici_simulation_core/core/data_format.py
@@ -87,11 +87,12 @@ class EntityInitDataFormat(ExternalSerializationStrategy):
 
             spec = self.schema.get_spec(name, default_data_type=infer_datatype, cache=True)
             data_type = spec.data_type
-
-            return t.cast(dict, parse_list(attr_data, data_type))
-
+            try:
+                return t.cast(dict, parse_list(attr_data, data_type))
+            except ValueError as e:
+                raise ValueError(f"Error when parsing data for '{name}': {e}") from e
         else:
-            raise TypeError("attribute data must be list")
+            raise TypeError(f"Attribute data for '{name}' must be list")
 
     def dumps(self, data: dict, filetype: FileType = FileType.JSON, **kwargs) -> bytes:
         self.supported_file_type_or_raise(filetype)
@@ -177,7 +178,10 @@ def create_array(uniform_data: list, data_type: DataType):
 
     # Otherwise we need to handle None values properly
     uniform_data = _substitute_undefined(uniform_data, undefined)
-    result = np.array(uniform_data, dtype=dtype)
+    try:
+        result = np.array(uniform_data, dtype=dtype)
+    except ValueError as e:
+        raise ValueError("invalid input data") from e
 
     if result.shape[1:] != data_type.unit_shape:
         # If we still do not have the correct shape, this means that the input data was incorrectly

--- a/packages/simulation-core/src/movici_simulation_core/core/data_format.py
+++ b/packages/simulation-core/src/movici_simulation_core/core/data_format.py
@@ -148,21 +148,43 @@ def parse_csr_list(data: t.List[list], data_type: DataType) -> NumpyAttributeDat
 
 
 def create_array(uniform_data: list, data_type: DataType):
+    dtype = data_type.np_type
+    if not uniform_data:
+        return np.array([], dtype=dtype)
+
     if data_type.unit_shape == ():
         undefined = data_type.undefined
     else:
         undefined = np.full(data_type.unit_shape, data_type.undefined)
 
-    dtype = data_type.np_type
     if np.issubdtype(dtype, str):
         uniform_data = _substitute_undefined(uniform_data, undefined)
         dtype = get_unicode_dtype(_max_str_length(uniform_data))
 
+    result = None
     try:
-        return np.array(uniform_data, dtype=dtype)
+        # Try optimistically, this may produce an array with an incorrect shape in case of
+        # floating point arrays (`[None, None]` for multidimensional arrays is converted to
+        # `[nan, nan]`, which is wrong). For other data types, `None` in inputs always raises an
+        # error, as well as mismatched shapes.
+        result = np.array(uniform_data, dtype=dtype)
     except (ValueError, TypeError):
-        uniform_data = _substitute_undefined(uniform_data, undefined)
-        return np.array(uniform_data, dtype=dtype)
+        pass
+
+    if result is not None and result.shape[1:] == data_type.unit_shape:
+        # If all went well and we have the correct shape, we can return the array
+        return result
+
+    # Otherwise we need to handle None values properly
+    uniform_data = _substitute_undefined(uniform_data, undefined)
+    result = np.array(uniform_data, dtype=dtype)
+
+    if result.shape[1:] != data_type.unit_shape:
+        # If we still do not have the correct shape, this means that the input data was incorrectly
+        # shaped
+        raise ValueError("input data is not of the correct shape")
+
+    return result
 
 
 def _substitute_undefined(uniform_data, undefined):

--- a/packages/simulation-core/tests/core/test_data_format.py
+++ b/packages/simulation-core/tests/core/test_data_format.py
@@ -77,10 +77,23 @@ def test_init_data_format(list_init_data, array_init_data, schema):
 @pytest.mark.parametrize(
     "data_type, py_data, expected",
     [
+        (DataType(float, (), False), [], np.array([], dtype=float)),
+        (DataType(int, (), False), [], np.array([], dtype=int)),
+        (DataType(float, (2,), False), [], np.array([], dtype=float)),
         (DataType(int, (), False), [1, None], np.array([1, UNDEFINED[int]])),
         (DataType(float, (), False), [1, None], np.array([1, UNDEFINED[float]])),
         (DataType(str, (), False), ["1", None], np.array(["1", UNDEFINED[str]])),
         (DataType(bool, (), False), [True, None], np.array([True, UNDEFINED[bool]])),
+        (
+            DataType(int, (2,), csr=True),
+            [None, None],
+            np.array([[UNDEFINED[int], UNDEFINED[int]], [UNDEFINED[int], UNDEFINED[int]]]),
+        ),
+        (
+            DataType(float, (2,), csr=True),
+            [None, None],
+            np.array([[UNDEFINED[float], UNDEFINED[float]], [UNDEFINED[float], UNDEFINED[float]]]),
+        ),
         (
             DataType(int, (2,), False),
             [[1, 1], None],
@@ -113,10 +126,24 @@ def test_init_data_format(list_init_data, array_init_data, schema):
 )
 def test_create_array(data_type, py_data, expected):
     result = create_array(py_data, data_type)
+    assert result.shape == expected.shape
     if data_type.py_type is float:
         assert np.allclose(result, expected, equal_nan=True)
     else:
         assert np.array_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    "data_type, py_data",
+    [
+        (DataType(float), [[1.0, 2.0]]),
+        (DataType(float, (2,), csr=True), [1.0, 2.0]),
+        (DataType(float, (2,)), [[1.0, 2.0, 3.0]]),
+    ],
+)
+def test_create_array_raises_on_shape_mismatch(data_type, py_data):
+    with pytest.raises(ValueError):
+        create_array(py_data, data_type)
 
 
 @pytest.mark.parametrize(

--- a/packages/simulation-core/tests/core/test_data_format.py
+++ b/packages/simulation-core/tests/core/test_data_format.py
@@ -142,7 +142,7 @@ def test_create_array(data_type, py_data, expected):
     ],
 )
 def test_create_array_raises_on_shape_mismatch(data_type, py_data):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="input data is not of the correct shape"):
         create_array(py_data, data_type)
 
 


### PR DESCRIPTION
Describe your changes
--------------------
When ``EntityInitDataFormat`` reads input data, we do not validate the shape of the input data arrays, which may lead to incorrect data arrays.

Furthermore, input data with only `None` values were always converted into 1D arrays which is not correct when we have a multidimensional attribute data type.

This PR fixes both these issues

Copyright license
-----------------

Please tick the following box:
 - [x] I hereby grant a full copyright license to NGinfra to use my contribution. This includes but
 is not limited to permission to use my contribution in a commercial setting and to
 re-/sublicense my contribution
